### PR TITLE
Don't panic if the handler is a struct

### DIFF
--- a/wrappers/hnygorilla/gorilla.go
+++ b/wrappers/hnygorilla/gorilla.go
@@ -40,10 +40,13 @@ func Middleware(handler http.Handler) http.Handler {
 		route := mux.CurrentRoute(r)
 		if route != nil {
 			chosenHandler := route.GetHandler()
-			funcName := runtime.FuncForPC(reflect.ValueOf(chosenHandler).Pointer()).Name()
-			ev.AddField("handler.fnname", funcName)
-			if funcName != "" {
-				ev.AddField("name", funcName)
+			reflectHandler := reflect.ValueOf(chosenHandler)
+			if reflectHandler.Kind() == reflect.Func {
+				funcName := runtime.FuncForPC(reflectHandler.Pointer()).Name()
+				ev.AddField("handler.fnname", funcName)
+				if funcName != "" {
+					ev.AddField("name", funcName)
+				}
 			}
 			name := route.GetName()
 			if name != "" {

--- a/wrappers/hnygorilla/gorilla_test.go
+++ b/wrappers/hnygorilla/gorilla_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testHandler struct{}
+
+func (testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(204)
+}
+
 func TestGorillaMiddleware(t *testing.T) {
 	// set up libhoney to catch events instead of send them
 	evCatcher := &libhoney.MockOutput{}
@@ -18,25 +24,40 @@ func TestGorillaMiddleware(t *testing.T) {
 		Dataset:  "efgh",
 		Output:   evCatcher,
 	})
-	// build a sample request to generate an event
-	r, _ := http.NewRequest("GET", "/hello/pooh", nil)
-	w := httptest.NewRecorder()
 
 	// build the gorilla mux router with Middleware
 	router := mux.NewRouter()
 	router.Use(Middleware)
 	router.HandleFunc("/hello/{name}", func(_ http.ResponseWriter, _ *http.Request) {})
-	// handle the request
-	router.ServeHTTP(w, r)
+	router.Handle("/yo", testHandler{})
 
-	// verify the MockOutput caught the well formed event
-	evs := evCatcher.Events()
-	assert.Equal(t, 1, len(evs), "one event is created with one request through the Middleware")
-	fields := evs[0].Fields()
-	status, ok := fields["response.status_code"]
-	assert.True(t, ok, "status field must exist on middleware generated event")
-	assert.Equal(t, 200, status, "successfully served request should have status 200")
-	name, ok := fields["gorilla.vars.name"]
-	assert.True(t, ok, "gorilla.vars.name field must exist on middleware generated event")
-	assert.Equal(t, "pooh", name, "successfully served request should have name var populated")
+	t.Run("function handler", func(t *testing.T) {
+		// build a sample request to generate an event
+		r, _ := http.NewRequest("GET", "/hello/pooh", nil)
+		w := httptest.NewRecorder()
+		// handle the request
+		router.ServeHTTP(w, r)
+
+		// verify the MockOutput caught the well formed event
+		evs := evCatcher.Events()
+		assert.Equal(t, 1, len(evs), "one event is created with one request through the Middleware")
+		fields := evs[0].Fields()
+		status, ok := fields["response.status_code"]
+		assert.True(t, ok, "status field must exist on middleware generated event")
+		assert.Equal(t, 200, status, "successfully served request should have status 200")
+		name, ok := fields["gorilla.vars.name"]
+		assert.True(t, ok, "gorilla.vars.name field must exist on middleware generated event")
+		assert.Equal(t, "pooh", name, "successfully served request should have name var populated")
+	})
+
+	t.Run("struct handler should not panic", func(t *testing.T) {
+		// build a sample request to generate an event
+		r, _ := http.NewRequest("GET", "/yo", nil)
+		w := httptest.NewRecorder()
+		// handle the request
+		router.ServeHTTP(w, r)
+
+		evs := evCatcher.Events()
+		assert.Equal(t, 2, len(evs))
+	})
 }


### PR DESCRIPTION
We use structs for our handlers. Getting the function name will panic as a result. This corrects that.