### PR TITLE
add functions to marshal and unmarshal trace contxet to enable tracing

### DIFF
--- a/internal/propagation.go
+++ b/internal/propagation.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// assumes a header of the form:
+
+// VERSION;PAYLOAD
+
+// VERSION=1
+// =========
+// PAYLOAD is a list of comma-separated params (k=v pairs), with no spaces.  recognized
+// keys + value types:
+//
+//  trace_id=${traceId}    - traceId is an opaque ascii string which shall not include ','
+//  parent_id=${spanId}    - spanId is an opaque ascii string which shall not include ','
+//  context=${contextBlob} - contextBlob is a base64 encoded json object.
+//
+// ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
+
+const (
+	TracePropagationHTTPHeader = "X-Honeycomb-Trace"
+	TracePropagationVersion    = 1
+)
+
+type Propagation struct {
+	TraceHeader
+	TraceContext       map[string]interface{}
+	TraceContextBase64 string
+}
+
+type PropagationError struct {
+	message      string
+	wrappedError error
+}
+
+func (p *PropagationError) Error() string {
+	if p.wrappedError == nil {
+		return p.message
+	}
+	return fmt.Sprintf(p.message, p.wrappedError)
+}
+
+func MarshalTraceContext(ctx context.Context) string {
+	trace := GetTraceFromContext(ctx)
+	currentSpan := trace.openSpans[len(trace.openSpans)-1]
+
+	var prop = &Propagation{}
+	prop.Source = HeaderSourceBeeline
+	prop.TraceID = trace.headers.TraceID
+	prop.ParentID = currentSpan.spanID
+	prop.TraceContext = trace.traceLevelFields
+
+	tcJSON, err := json.Marshal(prop.TraceContext)
+	if err != nil {
+		// if we couldn't marshal the trace level fields, leave it blank
+		tcJSON = []byte("")
+	}
+
+	tcB64 := base64.StdEncoding.EncodeToString(tcJSON)
+
+	return fmt.Sprintf("%d;trace_id=%s,parent_id=%s,context=%s",
+		TracePropagationVersion, prop.TraceID, prop.ParentID, tcB64)
+}
+
+func UnmarshalTraceContext(header string) (*TraceHeader, map[string]interface{}, error) {
+	// pull the version out of the header
+	getVer := strings.SplitN(header, ";", 2)
+	if getVer[0] == "1" {
+		return UnmarshalTraceContextV1(getVer[1])
+	}
+	return nil, nil, &PropagationError{fmt.Sprintf("unrecognized version for trace header %s", getVer[0]), nil}
+}
+
+// UnmarshalTraceContextV1 takes the trace header, stripped of the version
+// string, and returns the component parts. Trace ID and Parent ID are both
+// required. If either is absent a nil trace header will be returned.
+func UnmarshalTraceContextV1(header string) (*TraceHeader, map[string]interface{}, error) {
+	clauses := strings.Split(header, ",")
+	var prop = &Propagation{}
+	prop.Source = HeaderSourceBeeline
+	for _, clause := range clauses {
+		keyval := strings.SplitN(clause, "=", 2)
+		switch keyval[0] {
+		case "trace_id":
+			prop.TraceID = keyval[1]
+		case "parent_id":
+			prop.ParentID = keyval[1]
+		case "context":
+			prop.TraceContextBase64 = keyval[1]
+		}
+	}
+	if prop.TraceID == "" {
+		return nil, nil, &PropagationError{"missing trace ID", nil}
+	}
+	if prop.ParentID == "" {
+		return nil, nil, &PropagationError{"missing parent ID", nil}
+	}
+	if prop.TraceContextBase64 != "" {
+		data, err := base64.StdEncoding.DecodeString(prop.TraceContextBase64)
+		if err != nil {
+			return nil, nil, &PropagationError{"unable to decode base64 trace context", err}
+		}
+		prop.TraceContext = make(map[string]interface{})
+		err = json.Unmarshal(data, &prop.TraceContext)
+		if err != nil {
+			return nil, nil, &PropagationError{"unable to unmarshal trace context", err}
+		}
+	}
+	return &prop.TraceHeader, prop.TraceContext, nil
+}

--- a/internal/propagation_test.go
+++ b/internal/propagation_test.go
@@ -1,0 +1,133 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testHeaders = TraceHeader{
+	Source:   HeaderSourceBeeline,
+	TraceID:  "abcdef123456",
+	ParentID: "0102030405",
+}
+var testTrace = &Trace{
+	headers: testHeaders,
+	openSpans: []*Span{
+		&Span{
+			spanID: "0102030405",
+		},
+	},
+	traceLevelFields: map[string]interface{}{
+		"userID":   float64(1),
+		"errorMsg": "failed to sign on",
+		"toRetry":  true,
+	},
+}
+
+func TestMarshalTraceContext(t *testing.T) {
+	ctx, err := PutTraceInContext(context.TODO(), testTrace)
+	assert.Nil(t, err, "Put trace in context should not error")
+	marshaled := MarshalTraceContext(ctx)
+	assert.Equal(t, "1;", marshaled[0:2])
+}
+
+func TestUnmarshalTraceContext(t *testing.T) {
+	testCases := []struct {
+		name         string
+		contextStr   string
+		valueHeader  *TraceHeader
+		valueContext map[string]interface{}
+		returnsErr   bool
+	}{
+		{
+			"unsupported version",
+			"999999;....",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"v1 trace_id + parent_id, missing context",
+			"1;trace_id=abcdef,parent_id=12345",
+			&TraceHeader{
+				Source:   HeaderSourceBeeline,
+				TraceID:  "abcdef",
+				ParentID: "12345",
+			},
+			nil,
+			false,
+		},
+		{
+			"v1, all headers and legit context",
+			"1;trace_id=abcdef,parent_id=12345,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==",
+			&TraceHeader{
+				Source:   HeaderSourceBeeline,
+				TraceID:  "abcdef",
+				ParentID: "12345",
+			},
+			map[string]interface{}{
+				"userID":   float64(1),
+				"errorMsg": "failed to sign on",
+				"toRetry":  true,
+			},
+			false,
+		},
+		{
+			"v1, missing trace_id",
+			"1;parent_id=12345",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"v1, missing parent_id",
+			"1;trace_id=12345",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"v1, garbled context",
+			"1;trace_id=abcdef,parent_id=12345,context=123~!@@&^@",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"v1, unknown key (otherwise valid)",
+			"1;trace_id=abcdef,parent_id=12345,something=unsupported",
+			&TraceHeader{
+				Source:   HeaderSourceBeeline,
+				TraceID:  "abcdef",
+				ParentID: "12345",
+			},
+			nil,
+			false,
+		},
+	}
+
+	for _, tt := range testCases {
+		header, fields, err := UnmarshalTraceContext(tt.contextStr)
+		assert.Equal(t, tt.valueHeader, header, tt.name)
+		assert.Equal(t, tt.valueContext, fields, tt.name)
+		if tt.returnsErr {
+			assert.Error(t, err, tt.name)
+		} else {
+			assert.NoError(t, err, tt.name)
+		}
+	}
+}
+
+// TestContextPropagationRoundTrip encodes some things then decodes them and
+// expects to get back the same thing it put in
+func TestContextPropagationRoundTrip(t *testing.T) {
+	ctx, err := PutTraceInContext(context.TODO(), testTrace)
+	assert.Nil(t, err, "Put trace in context should not error")
+	marshaled := MarshalTraceContext(ctx)
+	header, fields, err := UnmarshalTraceContext(marshaled)
+	assert.Equal(t, &testHeaders, header, "roundtrip headers")
+	assert.Equal(t, testTrace.traceLevelFields, fields, "roundtrip context")
+	assert.NoError(t, err, "roundtrip error")
+}


### PR DESCRIPTION
These headers match those in the node beeline for compatibility. See https://github.com/honeycombio/beeline-nodejs/blob/master/lib/propagation.js and the corresponding tests.

Test plan: go test. Compare tests to node, same tests passing should mean they're compatible.