### PR TITLE
Switch to using request.Host for getting the host header

### DIFF
--- a/examples/goji/main.go
+++ b/examples/goji/main.go
@@ -70,7 +70,7 @@ func bye(w http.ResponseWriter, r *http.Request) {
 //     "name": "main.hello",
 //     "request.content_length": 0,
 //     "request.header.user_agent": "curl/7.54.0",
-//     "request.host": "",
+//     "request.host": "localhost:8080",
 //     "request.http_version": "HTTP/1.1",
 //     "request.method": "GET",
 //     "request.path": "/hello/ben",

--- a/examples/gorilla/main.go
+++ b/examples/gorilla/main.go
@@ -57,7 +57,7 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 //     "meta.type": "http request",
 //     "request.content_length": 0,
 //     "request.header.user_agent": "curl/7.54.0",
-//     "request.host": "",
+//     "request.host": "localhost:8080",
 //     "request.method": "GET",
 //     "request.path": "/hello/foo",
 //     "request.proto": "HTTP/1.1",

--- a/examples/http_and_sql/main.go
+++ b/examples/http_and_sql/main.go
@@ -94,7 +94,7 @@ func (a *app) hello(w http.ResponseWriter, r *http.Request) {
 //     "mux.handler.type": "http.HandlerFunc",
 //     "request.content_length": 0,
 //     "request.header.user_agent": "curl/7.54.0",
-//     "request.host": "",
+//     "request.host": "localhost:8080",
 //     "request.method": "GET",
 //     "request.path": "/hello/foo",
 //     "request.proto": "HTTP/1.1",

--- a/examples/httprouter/main.go
+++ b/examples/httprouter/main.go
@@ -52,7 +52,7 @@ func Hello(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 //     "meta.type": "http request",
 //     "request.content_length": 0,
 //     "request.header.user_agent": "curl/7.54.0",
-//     "request.host": "",
+//     "request.host": "localhost:8080",
 //     "request.method": "GET",
 //     "request.path": "/hello/foo",
 //     "request.proto": "HTTP/1.1",

--- a/examples/nethttpfunc/main.go
+++ b/examples/nethttpfunc/main.go
@@ -45,7 +45,7 @@ func helloServer(w http.ResponseWriter, req *http.Request) {
 //     "meta.type": "http request",
 //     "request.content_length": 0,
 //     "request.header.user_agent": "curl/7.54.0",
-//     "request.host": "",
+//     "request.host": "localhost:8080",
 //     "request.method": "GET",
 //     "request.path": "/hello",
 //     "request.proto": "HTTP/1.1",

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -38,7 +38,7 @@ func AddRequestProps(req *http.Request, ev *libhoney.Event) {
 	// and method, to any created libhoney event.
 	ev.AddField("request.method", req.Method)
 	ev.AddField("request.path", req.URL.Path)
-	ev.AddField("request.host", req.URL.Host)
+	ev.AddField("request.host", req.Host)
 	ev.AddField("request.http_version", req.Proto)
 	ev.AddField("request.content_length", req.ContentLength)
 	ev.AddField("request.remote_addr", req.RemoteAddr)

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -19,3 +19,20 @@ func TestParseTraceHeader(t *testing.T) {
 	assert.Equal(t, "1-67891233-abcdef012345678912345678", fs["request.header.aws_trace_id.Root"])
 	assert.Equal(t, "app", fs["request.header.aws_trace_id.CalledFrom"])
 }
+
+func TestHostHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Host", "example.com")
+	ev := libhoney.NewEvent()
+	AddRequestProps(req, ev)
+	fs := ev.Fields()
+	assert.Equal(t, "example.com", fs["request.host"])
+}
+
+func TestURLHostHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "https://example.com/", nil)
+	ev := libhoney.NewEvent()
+	AddRequestProps(req, ev)
+	fs := ev.Fields()
+	assert.Equal(t, "example.com", fs["request.host"])
+}


### PR DESCRIPTION
`req.URL.Host` doesn't appear to populate Honeycomb with an actual value. Switching to `req.Host` works in the case of 
* `curl localhost:8080/hello/hi`
* `curl -H "Host: example.com" localhost:8080/hello/hi`

**Testing**
- [x] `go test` passes
- [x] Confirmed all provided examples not send a proper value in the `request.host`field

