### PR TITLE
Commit with context

### DIFF
--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -1842,6 +1842,21 @@ func (tx *Tx) Rollback() error {
 	return err
 }
 
+func (tx *Tx) Rollbackx(ctx context.Context) error {
+	var err error
+	_, sender := internal.BuildDBEvent(ctx, tx.Builder, "")
+	defer sender(err)
+
+	// ensure any changes to the Mapper get passed along
+	if tx.Mapper != nil {
+		tx.wtx.Mapper = tx.Mapper
+	}
+
+	// do DB call
+	err = tx.wtx.Rollback()
+	return err
+}
+
 func (tx *Tx) Select(dest interface{}, query string, args ...interface{}) error {
 	var err error
 	ev, sender := internal.BuildDBEvent(context.Background(), tx.Builder, query, args...)

--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -1300,7 +1300,7 @@ func (tx *Tx) Commit() error {
 	return err
 }
 
-// Commitx adds a commit that can be passed a context in order
+// Commitx is the same as `Commit`, but is passed a context
 // to ensure that commits show up as part of a parent trace
 func (tx *Tx) Commitx(ctx context.Context) error {
 	var err error

--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -1299,6 +1299,24 @@ func (tx *Tx) Commit() error {
 	err = tx.wtx.Commit()
 	return err
 }
+
+// Commitx adds a commit that can be passed a context in order
+// to ensure that commits show up as part of a parent trace
+func (tx *Tx) Commitx(ctx context.Context) error {
+	var err error
+	_, sender := internal.BuildDBEvent(ctx, tx.Builder, "")
+	defer sender(err)
+
+	// ensure any changes to the Mapper get passed along
+	if tx.Mapper != nil {
+		tx.wtx.Mapper = tx.Mapper
+	}
+
+	// do DB call
+	err = tx.wtx.Commit()
+	return err
+}
+
 func (tx *Tx) DriverName() string {
 	var err error
 	_, sender := internal.BuildDBEvent(context.Background(), tx.Builder, "")

--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -1300,9 +1300,9 @@ func (tx *Tx) Commit() error {
 	return err
 }
 
-// Commitx is the same as `Commit`, but is passed a context
+// CommitContext is the same as `Commit`, but is passed a context
 // to ensure that commits show up as part of a parent trace
-func (tx *Tx) Commitx(ctx context.Context) error {
+func (tx *Tx) CommitContext(ctx context.Context) error {
 	var err error
 	_, sender := internal.BuildDBEvent(ctx, tx.Builder, "")
 	defer sender(err)
@@ -1842,7 +1842,7 @@ func (tx *Tx) Rollback() error {
 	return err
 }
 
-func (tx *Tx) Rollbackx(ctx context.Context) error {
+func (tx *Tx) RollbackContext(ctx context.Context) error {
 	var err error
 	_, sender := internal.BuildDBEvent(ctx, tx.Builder, "")
 	defer sender(err)


### PR DESCRIPTION
Add a method so that when a transaction is comitted, the commit shows up as part of the trace instead of being orphaned.