### PR TITLE
Prevent obscuring optional http.ResponseWriter methods.

### DIFF
--- a/wrappers/hnygoji/goji.go
+++ b/wrappers/hnygoji/goji.go
@@ -54,7 +54,7 @@ func Middleware(handler http.Handler) http.Handler {
 			}
 		}
 		// TODO get all the parameters and their values
-		handler.ServeHTTP(wrappedWriter, r)
+		handler.ServeHTTP(wrappedWriter.Wrapped, r)
 		if wrappedWriter.Status == 0 {
 			wrappedWriter.Status = 200
 		}

--- a/wrappers/hnygorilla/gorilla.go
+++ b/wrappers/hnygorilla/gorilla.go
@@ -54,7 +54,7 @@ func Middleware(handler http.Handler) http.Handler {
 				span.AddField("handler.route", path)
 			}
 		}
-		handler.ServeHTTP(wrappedWriter, r)
+		handler.ServeHTTP(wrappedWriter.Wrapped, r)
 		if wrappedWriter.Status == 0 {
 			wrappedWriter.Status = 200
 		}

--- a/wrappers/hnyhttprouter/httprouter.go
+++ b/wrappers/hnyhttprouter/httprouter.go
@@ -30,7 +30,7 @@ func Middleware(handle httprouter.Handle) httprouter.Handle {
 		span.AddField("handler.name", name)
 		span.AddField("name", name)
 
-		handle(wrappedWriter, r, ps)
+		handle(wrappedWriter.Wrapped, r, ps)
 
 		if wrappedWriter.Status == 0 {
 			wrappedWriter.Status = 200

--- a/wrappers/hnynethttp/nethttp.go
+++ b/wrappers/hnynethttp/nethttp.go
@@ -48,7 +48,7 @@ func WrapHandler(handler http.Handler) http.Handler {
 			}
 		}
 
-		handler.ServeHTTP(wrappedWriter, r)
+		handler.ServeHTTP(wrappedWriter.Wrapped, r)
 		if wrappedWriter.Status == 0 {
 			wrappedWriter.Status = 200
 		}
@@ -75,7 +75,7 @@ func WrapHandlerFunc(hf func(http.ResponseWriter, *http.Request)) func(http.Resp
 			span.AddField("name", handlerFuncName)
 		}
 
-		hf(wrappedWriter, r)
+		hf(wrappedWriter.Wrapped, r)
 		if wrappedWriter.Status == 0 {
 			wrappedWriter.Status = 200
 		}


### PR DESCRIPTION
* Use the ResponseWriter returned from httpsnoop.Wrap so that optional methods are still exposed on the concrete type.
* Only record the first set status code.

I'm not sure `ResponseWriter` is a good name for the struct anymore. I considered renaming it to `ResponseRecorder` but didn't want to make too many changes.

Resolves #18 