### PR TITLE
fix rollup - fields should be added to the root span

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -213,7 +213,7 @@ func (s *Span) Send() {
 		s.ev.AddField("trace.parent_id", s.parentID)
 	}
 	s.ev.AddField("trace.span_id", s.spanID)
-	// add rollup fields to the event
+	// add this span's rollup fields to the event
 	for k, v := range s.rollupFields {
 		s.ev.AddField(k, v)
 	}
@@ -313,6 +313,13 @@ func (s *Span) send() {
 		spanType = "mid"
 	}
 	s.AddField("meta.span_type", spanType)
+
+	if spanType == "root" {
+		// add the trace's rollup fields to the root span
+		for k, v := range s.trace.rollupFields {
+			s.ev.AddField("rollup."+k, v)
+		}
+	}
 
 	// run hooks
 	var shouldKeep = true

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -150,6 +150,7 @@ func TestSpan(t *testing.T) {
 	span.AddField("f1", "v1")
 	assert.Equal(t, "v1", span.ev.Fields()["f1"].(string), "after adding a field, field should exist on the span")
 
+	// add some rollup fields
 	span.AddRollupField("r1", 2)
 	span.AddRollupField("r1", 3)
 	asyncSpan.AddRollupField("r1", 7)
@@ -199,6 +200,7 @@ func TestSpan(t *testing.T) {
 		case "root":
 			foundRoot = true
 			assert.Nil(t, ev.Fields()["trace.parent_id"], "root span should have no parent ID")
+			assert.Equal(t, float64(12), ev.Fields()["rollup.r1"], "root span should have rolled up fields")
 		case "async":
 			foundAsync = true
 		case "leaf":


### PR DESCRIPTION
Added test confirming that rolled up fields actually get set on the root span.  They didn't. Fixed the code so they do. Tests pass.  Yay!