### PR TITLE
knowing which sql function is called is nice; knowing who called it is nicer.

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "0.2.2"
+const version = "0.2.3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "0.2.3"
+const version = "0.2.2"

--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -82,11 +82,21 @@ func GetRequestProps(req *http.Request) map[string]interface{} {
 func sharedDBEvent(bld *libhoney.Builder, query string, args ...interface{}) *libhoney.Event {
 	ev := bld.NewEvent()
 	// get the name of the function that called this one. Strip the package and type
-	pc, _, _, _ := runtime.Caller(2)
-	callName := runtime.FuncForPC(pc).Name()
-	callNameChunks := strings.Split(callName, ".")
-	ev.AddField("db.call", callNameChunks[len(callNameChunks)-1])
-	ev.AddField("name", callNameChunks[len(callNameChunks)-1])
+	pc, _, _, ok := runtime.Caller(2)
+	if ok {
+		callName := runtime.FuncForPC(pc).Name()
+		callNameChunks := strings.Split(callName, ".")
+		ev.AddField("db.call", callNameChunks[len(callNameChunks)-1])
+		ev.AddField("name", callNameChunks[len(callNameChunks)-1])
+	}
+
+	// and two levels up
+	pc, _, _, ok = runtime.Caller(3)
+	if ok {
+		callName := runtime.FuncForPC(pc).Name()
+		callNameChunks := strings.Split(callName, ".")
+		ev.AddField("db.caller", callNameChunks[len(callNameChunks)-1])
+	}
 
 	if query != "" {
 		ev.AddField("db.query", query)

--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -79,23 +79,43 @@ func GetRequestProps(req *http.Request) map[string]interface{} {
 	return reqProps
 }
 
+// getCallersNames grabs the current call stack, skips up a few levels, then
+// grabs as many function names as depth. Suggested use is something like 1, 2
+// meaning "get my parent and its parent". skip=0 means the function calling
+// this one.
+func getCallersNames(skip, depth int) []string {
+	callers := make([]string, 0, depth)
+	callerPcs := make([]uintptr, depth)
+	// add 2 to skip to account for runtime.Callers and getCallersNames
+	numCallers := runtime.Callers(skip+2, callerPcs)
+	// If there are no callers, the entire stacktrace is nil
+	if numCallers == 0 {
+		return callers
+	}
+	callersFrames := runtime.CallersFrames(callerPcs)
+	for i := 0; i < depth; i++ {
+		fr, more := callersFrames.Next()
+		// store the function's name
+		nameParts := strings.Split(fr.Function, ".")
+		callers = append(callers, nameParts[len(nameParts)-1])
+		if !more {
+			break
+		}
+	}
+	return callers
+}
+
 func sharedDBEvent(bld *libhoney.Builder, query string, args ...interface{}) *libhoney.Event {
 	ev := bld.NewEvent()
-	// get the name of the function that called this one. Strip the package and type
-	pc, _, _, ok := runtime.Caller(2)
-	if ok {
-		callName := runtime.FuncForPC(pc).Name()
-		callNameChunks := strings.Split(callName, ".")
-		ev.AddField("db.call", callNameChunks[len(callNameChunks)-1])
-		ev.AddField("name", callNameChunks[len(callNameChunks)-1])
-	}
 
-	// and two levels up
-	pc, _, _, ok = runtime.Caller(3)
-	if ok {
-		callName := runtime.FuncForPC(pc).Name()
-		callNameChunks := strings.Split(callName, ".")
-		ev.AddField("db.caller", callNameChunks[len(callNameChunks)-1])
+	// skip 2 - this one and the buildDB*, so we get the sqlx function and its parent
+	callerNames := getCallersNames(2, 2)
+	switch len(callerNames) {
+	case 2:
+		ev.AddField("db.call", callerNames[0])
+		ev.AddField("db.caller", callerNames[1])
+	case 1:
+		ev.AddField("db.call", callerNames[0])
 	}
 
 	if query != "" {


### PR DESCRIPTION
When trying to track down where I had missed threading context through an app to get to the db (having added the hnysqlx wrapper), I found it very difficult to tell from the SQL alone which call was missing the context thread. Adding the name of the function that called the sql function made it way nicer. 

eg:
```
db.call: GetContext
db.caller: FetchDatasetByID     <--- super useful
```
