### PR TITLE
bump version, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+Release v0.2.3 (2018-09-14)
+===
+
+### Bug Fixes
+* rollup fields were not getting the rolled up values added to the root span
+
+### New Field
+* sql and sqlx wrappers get both the DB call being made (eg Select) as well as the name of the function making the call (eg FetchThingsByID)
+
+Release v0.2.2 (2018-09-1)
+===
+
+### Bug Fixes
+* fix version number inconsistency with a patch bump
+
+Release v0.2.1 (2018-09-14)
+===
+
+### Bug Fixes
+* fix propagation bug when an incoming request has a serialized beeline trace header
+
 Release v0.2.0 (2018-09-12)
 ===
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "0.2.2"
+const version = "0.2.3"


### PR DESCRIPTION
to be landed after #24 and #25, assuming both get approved eventually.