### PR TITLE
Fix hnyhttprouter to pass wrapped ResponseWriter to handler

### DIFF
--- a/wrappers/hnyhttprouter/httprouter.go
+++ b/wrappers/hnyhttprouter/httprouter.go
@@ -30,7 +30,7 @@ func Middleware(handle httprouter.Handle) httprouter.Handle {
 		span.AddField("handler.name", name)
 		span.AddField("name", name)
 
-		handle(w, r, ps)
+		handle(wrappedWriter, r, ps)
 
 		if wrappedWriter.Status == 0 {
 			wrappedWriter.Status = 200

--- a/wrappers/hnyhttprouter/httprouter_test.go
+++ b/wrappers/hnyhttprouter/httprouter_test.go
@@ -33,9 +33,37 @@ func TestHTTPRouterMiddleware(t *testing.T) {
 	assert.Equal(t, 1, len(evs), "one event is created with one request through the Middleware")
 	fields := evs[0].Fields()
 	status, ok := fields["response.status_code"]
-	assert.True(t, ok, "status field must exist on middleware generated event")
+	assert.True(t, ok, "'status_code' field must exist on middleware generated event")
 	assert.Equal(t, 200, status, "successfully served request should have status 200")
 	name, ok := fields["handler.vars.name"]
 	assert.True(t, ok, "handler.vars.name field must exist on middleware generated event")
 	assert.Equal(t, "pooh", name, "successfully served request should have name var populated")
+}
+
+func TestHTTPRouterMiddlewareReturnsStatusCode(t *testing.T) {
+	// set up libhoney to catch events instead of send them
+	evCatcher := &libhoney.MockOutput{}
+	libhoney.Init(libhoney.Config{
+		WriteKey: "abcd",
+		Dataset:  "efgh",
+		Output:   evCatcher,
+	})
+
+	r, _ := http.NewRequest("GET", "/does_not_exist", nil)
+	w := httptest.NewRecorder()
+
+	router := httprouter.New()
+	handler := func(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+		w.WriteHeader(404)
+	}
+	router.GET("/does_not_exist", Middleware(handler))
+	router.ServeHTTP(w, r)
+
+	evs := evCatcher.Events()
+	assert.Equal(t, 1, len(evs), "one event is created with one request through the Middleware")
+	fields := evs[0].Fields()
+	status, ok := fields["response.status_code"]
+	assert.True(t, ok, "'status_code' field must exist on middleware generated event")
+	assert.Equal(t, http.StatusNotFound, status)
+
 }


### PR DESCRIPTION
`handle()` is called with the original `ResponseWriter` and not the wrapped `ResponseWriter`. So when the httprouter.Handle is called, the `Status` field on the writer is not touched. As a result, the middleware always emits `200` as the status code.
