### PR TITLE
add name back in as db call

### DIFF
--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -113,9 +113,13 @@ func sharedDBEvent(bld *libhoney.Builder, query string, args ...interface{}) *li
 	switch len(callerNames) {
 	case 2:
 		ev.AddField("db.call", callerNames[0])
+		ev.AddField("name", callerNames[0])
 		ev.AddField("db.caller", callerNames[1])
 	case 1:
 		ev.AddField("db.call", callerNames[0])
+		ev.AddField("name", callerNames[0])
+	default:
+		ev.AddField("name", "db")
 	}
 
 	if query != "" {

--- a/wrappers/common/common_test.go
+++ b/wrappers/common/common_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,4 +50,14 @@ func TestXForwardedProtoHeader(t *testing.T) {
 	req.Header.Set("X-Forwarded-Proto", xForwardedProto)
 	props := GetRequestProps(req)
 	assert.Equal(t, xForwardedProto, props["request.header.x_forwarded_proto"])
+}
+
+// TestSharedDBEvent verifies that the name field is set to something
+func TestSharedDBEvent(t *testing.T) {
+	bld := libhoney.NewBuilder()
+	query := "this is sql really promise"
+	// wrap it in another function to get the expected nesting right
+	var ev *libhoney.Event
+	func() { ev = sharedDBEvent(bld, query) }()
+	assert.Equal(t, "TestSharedDBEvent", ev.Fields()["name"], "should get a reasonable name")
 }


### PR DESCRIPTION
As part of the v1 -> v2 beeline I thought "having `db.call` repeated as `name` is redundant. But the Honeycomb UI defaults to using `name` as the span identifier so having it blank leads to traces that look like this:

![image 2018-10-03 at 11 43 38 pm](https://user-images.githubusercontent.com/361454/46457174-44d1ec80-c766-11e8-8afa-dbf91255d1be.png)

This change adds them back in - db.call is duplicated as `name`. 