### PR TITLE
Allow override of event batching configuration in libhoney

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Release v0.2.4 (2018-10-05)
+===
+
+### Minor Changes
+
+* Allow override of MaxConcurrentBatches, MaxBatchSize, and PendingWorkCapacity in `beeline.Config`
+* Sets default value for MaxConcurrentBatches to 20 (from 80), and PendingWorkCapacity to 1000 (from 10000).
+
 Release v0.2.3 (2018-09-14)
 ===
 

--- a/beeline.go
+++ b/beeline.go
@@ -61,6 +61,15 @@ type Config struct {
 	// trouble getting the beeline to work, set this to true in a dev
 	// environment.
 	Debug bool
+	// MaxConcurrentBatches, if set, will override the default number of
+	// goroutines (20) that are used to send batches of events in parallel.
+	MaxConcurrentBatches uint
+	// MaxBatchSize, if set, will override the default number of events
+	// (50) that are sent per batch.
+	MaxBatchSize uint
+	// PendingWorkCapacity overrides the default event queue size (1000).
+	// If the queue is full, events will be dropped.
+	PendingWorkCapacity uint
 }
 
 // Init intializes the honeycomb instrumentation library.
@@ -81,10 +90,22 @@ func Init(config Config) {
 	if config.Mute == true {
 		output = &libhoney.DiscardOutput{}
 	}
+	if config.MaxConcurrentBatches == 0 {
+		config.MaxConcurrentBatches = 20
+	}
+	if config.MaxBatchSize == 0 {
+		config.MaxBatchSize = 50
+	}
+	if config.PendingWorkCapacity == 0 {
+		config.PendingWorkCapacity = 1000
+	}
 	libhconfig := libhoney.Config{
-		WriteKey: config.WriteKey,
-		Dataset:  config.Dataset,
-		Output:   output,
+		WriteKey:             config.WriteKey,
+		Dataset:              config.Dataset,
+		Output:               output,
+		MaxConcurrentBatches: config.MaxConcurrentBatches,
+		MaxBatchSize:         config.MaxBatchSize,
+		PendingWorkCapacity:  config.PendingWorkCapacity,
 	}
 	if config.APIHost != "" {
 		libhconfig.APIHost = config.APIHost

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "0.2.3"
+const version = "0.2.4"


### PR DESCRIPTION
Libhoney's default configuration for batch goroutine count is pretty high (at 80), as is the config for PendingWorkCapacity. If the application is memory constrained, this could become an issue, especially if there are ingestion issues in the API, as events can pile up in the queue and the number of in flight-batches can max out. This diff sets some lower defaults, and adds configuration variables for overriding these values if desired.