### PR TITLE
Update example to fix beeline.Init

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -32,7 +32,7 @@
 // events.
 //
 //   func main() {
-//     beeline.Init(&beeline.Config{
+//     beeline.Init(beeline.Config{
 //       WriteKey: "abcabc123123defdef456456",
 //       Dataset: "myapp",
 //     })


### PR DESCRIPTION
beeline.Init doesn't take a reference. Bumped into this setting it up so I wanted to send back the doc update.