### PR TITLE
Asyncchild race

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: go
 go:
     - "1.10"
     - "1.9"
+script:
+    - "go test -v ./... -race"


### PR DESCRIPTION
This resolves https://github.com/honeycombio/beeline-go/issues/34 by adding a lock around the children slice on each span. I also turned on the race detector in CI. Prior to fixing the races, the test output was

```
$ go test ./trace -race
==================
WARNING: DATA RACE
Write at 0x00c0002ba008 by goroutine 30:
  github.com/honeycombio/beeline-go/trace.(*Span).CreateChild()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace.go:283 +0x27d
  github.com/honeycombio/beeline-go/trace.(*Span).CreateAsyncChild()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace.go:270 +0x50
  github.com/honeycombio/beeline-go/trace.TestCreateAsyncSpanDoesNotCauseRaceInSend.func2()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:233 +0x4c

Previous read at 0x00c0002ba008 by goroutine 29:
  github.com/honeycombio/beeline-go/trace.(*Span).Send()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace.go:237 +0x34e
  github.com/honeycombio/beeline-go/trace.TestCreateAsyncSpanDoesNotCauseRaceInSend.func1()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:229 +0x38

Goroutine 30 (running) created at:
  github.com/honeycombio/beeline-go/trace.TestCreateAsyncSpanDoesNotCauseRaceInSend()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:232 +0x196
  testing.tRunner()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:827 +0x162

Goroutine 29 (finished) created at:
  github.com/honeycombio/beeline-go/trace.TestCreateAsyncSpanDoesNotCauseRaceInSend()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:228 +0x156
  testing.tRunner()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:827 +0x162
==================
--- FAIL: TestCreateAsyncSpanDoesNotCauseRaceInSend (0.00s)
    testing.go:771: race detected during execution of test
==================
WARNING: DATA RACE
Read at 0x00000176af10 by goroutine 33:
  github.com/honeycombio/beeline-go/trace.(*Span).send()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace.go:349 +0x449
  github.com/honeycombio/beeline-go/trace.(*Span).Send()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace.go:246 +0x447
  github.com/honeycombio/beeline-go/trace.TestAddFieldDoesNotCauseRaceInSendHooks.func3()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:259 +0x67

Previous write at 0x00000176af10 by goroutine 31:
  github.com/honeycombio/beeline-go/trace.TestAddFieldDoesNotCauseRaceInSendHooks.func2()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:251 +0x3a
  github.com/honeycombio/beeline-go/trace.TestAddFieldDoesNotCauseRaceInSendHooks()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:276 +0x276
  testing.tRunner()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:827 +0x162

Goroutine 33 (running) created at:
  github.com/honeycombio/beeline-go/trace.TestAddFieldDoesNotCauseRaceInSendHooks()
      /Users/mikeatkins/go/src/github.com/honeycombio/beeline-go/trace/trace_test.go:256 +0xca
  testing.tRunner()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:827 +0x162

Goroutine 31 (running) created at:
  testing.(*T).Run()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:827 +0x162
  testing.runTests()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /Users/mikeatkins/.gvm/gos/go1.11/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:60 +0x221
==================
--- FAIL: TestAddFieldDoesNotCauseRaceInSendHooks (0.02s)
FAIL
FAIL    github.com/honeycombio/beeline-go/trace 0.050s
```

Now it's just `ok` 😉 