### PR TITLE
fix field name parity between resp.status_code and response.status_code

### DIFF
--- a/wrappers/hnynethttp/nethttp.go
+++ b/wrappers/hnynethttp/nethttp.go
@@ -143,7 +143,7 @@ func (ht *hnyTripper) spanRoundTrip(ctx context.Context, span *trace.Span, r *ht
 		// TODO should this error field be namespaced somehow
 		span.AddField("error", err.Error())
 	} else {
-		span.AddField("resp.status_code", resp.StatusCode)
+		span.AddField("response.status_code", resp.StatusCode)
 
 	}
 	return resp, err

--- a/wrappers/hnynethttp/nethttp_test.go
+++ b/wrappers/hnynethttp/nethttp_test.go
@@ -23,16 +23,28 @@ func TestWrapHandlerFunc(t *testing.T) {
 
 	// build the wrapped handhler on the default mux
 	http.HandleFunc("/hello", WrapHandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-	// handle the request
+	http.HandleFunc("/fail", WrapHandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusTeapot) }))
+
+	// handle successful request
+	http.DefaultServeMux.ServeHTTP(w, r)
+
+	// set up + handle failed request
+	r, _ = http.NewRequest("GET", "/fail", nil)
+	w = httptest.NewRecorder()
 	http.DefaultServeMux.ServeHTTP(w, r)
 
 	// verify the MockOutput caught the well formed event
 	evs := evCatcher.Events()
-	assert.Equal(t, 1, len(evs), "one event is created with one request through the wrapped handler function")
-	fields := evs[0].Fields()
-	status, ok := fields["response.status_code"]
+	assert.Equal(t, 2, len(evs), "one event is created with one request through the wrapped handler function")
+	successfulFields := evs[0].Fields()
+	status, ok := successfulFields["response.status_code"]
 	assert.True(t, ok, "status field must exist on middleware generated event")
 	assert.Equal(t, 200, status, "successfully served request should have status 200")
+
+	failedFields := evs[1].Fields()
+	status, ok = failedFields["response.status_code"]
+	assert.True(t, ok, "status field must exist on middleware generated event")
+	assert.Equal(t, http.StatusTeapot, status, "served /fail request should have status 418")
 }
 
 func TestWrapHandler(t *testing.T) {
@@ -50,14 +62,25 @@ func TestWrapHandler(t *testing.T) {
 	// build the wrapped handler
 	globalmux := http.NewServeMux()
 	globalmux.HandleFunc("/hello", func(_ http.ResponseWriter, _ *http.Request) {})
+	globalmux.HandleFunc("/fail", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusTeapot) })
 	// handle the request
 	WrapHandler(globalmux).ServeHTTP(w, r)
 
+	// set up + handle failed request
+	r, _ = http.NewRequest("GET", "/fail", nil)
+	w = httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(w, r)
+
 	// verify the MockOutput caught the well formed event
 	evs := evCatcher.Events()
-	assert.Equal(t, 1, len(evs), "one event is created with one request through the Middleware")
+	assert.Equal(t, 2, len(evs), "one event is created with one request through the Middleware")
 	fields := evs[0].Fields()
 	status, ok := fields["response.status_code"]
 	assert.True(t, ok, "status field must exist on middleware generated event")
 	assert.Equal(t, 200, status, "successfully served request should have status 200")
+
+	failedFields := evs[1].Fields()
+	status, ok = failedFields["response.status_code"]
+	assert.True(t, ok, "status field must exist on middleware generated event")
+	assert.Equal(t, http.StatusTeapot, status, "served /fail request should have status 418")
 }


### PR DESCRIPTION
The other status codes in this file are returned with the field name `resp.status_code`; this one should not be an odd duckling. =\ (Will defer to you wrt how we roll this out.)

Also added to the tests to convince myself that the response status code is in fact being set correctly.