### PR TITLE
add url queries, add name even when empty

### DIFF
--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -75,6 +75,10 @@ func GetRequestProps(req *http.Request) map[string]interface{} {
 	// and method, to any created libhoney event.
 	reqProps["request.method"] = req.Method
 	reqProps["request.path"] = req.URL.Path
+	if req.URL.RawQuery != "" {
+		reqProps["request.query"] = req.URL.RawQuery
+	}
+	reqProps["request.url"] = req.URL.String()
 	reqProps["request.host"] = req.Host
 	reqProps["request.http_version"] = req.Proto
 	reqProps["request.content_length"] = req.ContentLength

--- a/wrappers/hnynethttp/nethttp.go
+++ b/wrappers/hnynethttp/nethttp.go
@@ -45,6 +45,9 @@ func WrapHandler(handler http.Handler) http.Handler {
 			if handlerName != "" {
 				span.AddField("handler.name", handlerName)
 				span.AddField("name", handlerName)
+			} else {
+				// we always want a name, even if it's kinda useless.
+				span.AddField("name", "handler")
 			}
 		}
 


### PR DESCRIPTION
There was nothing in the beeline that would show you the full URL requested. This adds that under `request.url` and also adds just the query portion of the URL at `request.query`. The URL is close to path + query, but is actually more - anchors (#foo) will appear in the URL but aren't explicitly called out into their own field here.