### PR TITLE
Propagate dataset in serialized headers

### DIFF
--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -20,6 +20,28 @@ func TestMarshalTraceContext(t *testing.T) {
 	marshaled := MarshalTraceContext(prop)
 	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
 	assert.Equal(t, "1;trace_id=abcdef123456,parent_id=0102030405,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==", marshaled)
+
+	returned, err := UnmarshalTraceContext(marshaled)
+	assert.Equal(t, prop, returned, "roundtrip object")
+	assert.NoError(t, err, "roundtrip error")
+
+	prop.Dataset = "imadataset"
+	marshaled = MarshalTraceContext(prop)
+	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
+	assert.Equal(t, "1;trace_id=abcdef123456,parent_id=0102030405,dataset=imadataset,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==", marshaled)
+
+	returned, err = UnmarshalTraceContext(marshaled)
+	assert.Equal(t, prop, returned, "roundtrip object")
+	assert.NoError(t, err, "roundtrip error")
+
+	prop.Dataset = "ill;egal"
+	marshaled = MarshalTraceContext(prop)
+	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
+	assert.Equal(t, "1;trace_id=abcdef123456,parent_id=0102030405,dataset=ill%3Begal,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==", marshaled)
+
+	returned, err = UnmarshalTraceContext(marshaled)
+	assert.Equal(t, prop, returned, "roundtrip object")
+	assert.NoError(t, err, "roundtrip error")
 }
 
 func TestUnmarshalTraceContext(t *testing.T) {
@@ -110,22 +132,4 @@ func TestUnmarshalTraceContext(t *testing.T) {
 			assert.NoError(t, err, tt.name)
 		}
 	}
-}
-
-// TestContextPropagationRoundTrip encodes some things then decodes them and
-// expects to get back the same thing it put in
-func TestContextPropagationRoundTrip(t *testing.T) {
-	prop := &Propagation{
-		TraceID:  "abcdef123456",
-		ParentID: "0102030405",
-		TraceContext: map[string]interface{}{
-			"userID":   float64(1),
-			"errorMsg": "failed to sign on",
-			"toRetry":  true,
-		},
-	}
-	marshaled := MarshalTraceContext(prop)
-	returned, err := UnmarshalTraceContext(marshaled)
-	assert.Equal(t, prop, returned, "roundtrip object")
-	assert.NoError(t, err, "roundtrip error")
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -57,6 +57,9 @@ func NewTrace(ctx context.Context, serializedHeaders string) (context.Context, *
 			for k, v := range prop.TraceContext {
 				trace.traceLevelFields[k] = v
 			}
+			if prop.Dataset != "" {
+				trace.builder.Dataset = prop.Dataset
+			}
 		}
 	}
 	rootSpan := newSpan()
@@ -96,6 +99,7 @@ func (t *Trace) serializeHeaders(spanID string) string {
 	var prop = &propagation.Propagation{
 		TraceID:      t.traceID,
 		ParentID:     spanID,
+		Dataset:      t.builder.Dataset,
 		TraceContext: t.traceLevelFields,
 	}
 	t.tlfLock.RLock()

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "0.3.4"
+const version = "0.3.5"


### PR DESCRIPTION
if `NewTrace()` is given headers, uses the dataset of the parent trace rather than the default. This should make life easier in environments with more than one tracing dataset. Also, more determined users like myself could even, hypothetically, cook their own Propagation and use it to overcome this limitation of the API.