### PR TITLE
add a convenience function to copy the trace bits from one context to another

### DIFF
--- a/trace/context.go
+++ b/trace/context.go
@@ -61,7 +61,7 @@ func PutSpanInContext(ctx context.Context, span *Span) context.Context {
 // This is useful if you need to break context to launch a goroutine that
 // shouldn't be cancelled by the parent's cancellation context. It returns the
 // newly populated context. If it can't find a trace in the source context, it
-// returns the unchanged dest context with an error source context.
+// returns the unchanged dest context with an error.
 func CopyContext(dest context.Context, src context.Context) (context.Context, error) {
 	trace := GetTraceFromContext(src)
 	span := GetSpanFromContext(src)

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -27,3 +27,24 @@ func TestSpanFromContext(t *testing.T) {
 	spanInCtx = GetSpanFromContext(ctx)
 	assert.Equal(t, emptySpan, spanInCtx, "span in context should be span we put in the context")
 }
+
+func TestCopyContext(t *testing.T) {
+	ctx, tr := NewTrace(context.Background(), "")
+	rs := tr.GetRootSpan()
+
+	newCtx, err := CopyContext(context.Background(), ctx)
+	assert.NoError(t, err, "should not return error when trace and span are present")
+
+	trInCtx := GetTraceFromContext(newCtx)
+	spanInCtx := GetSpanFromContext(newCtx)
+
+	assert.Equal(t, trInCtx, tr, "expected to find the same trace in the new context after copy")
+	assert.Equal(t, spanInCtx, rs, "expected to find the same span in the new context after copy")
+}
+
+func TestCopyContextError(t *testing.T) {
+	newCtx, err := CopyContext(context.Background(), context.Background())
+	assert.NotNil(t, newCtx, "should return valid context even in errored state")
+	assert.Equal(t, err, ErrTraceNotFoundInContext, "should error when no trace is present in the context")
+
+}


### PR DESCRIPTION
When breaking context to isolate a section of code from a timeout or cancellation in its parent, it's necessary to create a new context for the isolated code. Copying the context bits that are necessary to continue the beeline trace is annoying; this function makes it a little bit easier.