### PR TITLE
improve handling of incomplete or broken serialized headers

### DIFF
--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -100,11 +100,8 @@ func UnmarshalTraceContextV1(header string) (*Propagation, error) {
 			tcB64 = keyval[1]
 		}
 	}
-	if prop.TraceID == "" {
-		return nil, &PropagationError{"missing trace ID", nil}
-	}
-	if prop.ParentID == "" {
-		return nil, &PropagationError{"missing parent ID", nil}
+	if prop.TraceID == "" && prop.ParentID != "" {
+		return nil, &PropagationError{"parent_id without trace_id", nil}
 	}
 	if tcB64 != "" {
 		data, err := base64.StdEncoding.DecodeString(tcB64)

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -42,6 +42,17 @@ func TestMarshalTraceContext(t *testing.T) {
 	returned, err = UnmarshalTraceContext(marshaled)
 	assert.Equal(t, prop, returned, "roundtrip object")
 	assert.NoError(t, err, "roundtrip error")
+
+	prop = &Propagation{
+		Dataset: "imadataset",
+	}
+	marshaled = MarshalTraceContext(prop)
+	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
+	assert.Equal(t, "1;trace_id=,parent_id=,dataset=imadataset,context=bnVsbA==", marshaled)
+
+	returned, err = UnmarshalTraceContext(marshaled)
+	assert.Equal(t, prop, returned, "roundtrip object")
+	assert.NoError(t, err, "roundtrip error")
 }
 
 func TestUnmarshalTraceContext(t *testing.T) {
@@ -81,7 +92,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 			false,
 		},
 		{
-			"v1, missing trace_id",
+			"v1, parent_id without trace_id",
 			"1;parent_id=12345",
 			nil,
 			true,
@@ -89,8 +100,10 @@ func TestUnmarshalTraceContext(t *testing.T) {
 		{
 			"v1, missing parent_id",
 			"1;trace_id=12345",
-			nil,
-			true,
+			&Propagation{
+				TraceID: "12345",
+			},
+			false,
 		},
 		{
 			"v1, garbled context",

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -47,9 +47,7 @@ func NewTrace(ctx context.Context, serializedHeaders string) (context.Context, *
 		rollupFields:     make(map[string]float64),
 		traceLevelFields: make(map[string]interface{}),
 	}
-	if serializedHeaders == "" {
-		trace.traceID = uuid.Must(uuid.NewRandom()).String()
-	} else {
+	if serializedHeaders != "" {
 		prop, err := propagation.UnmarshalTraceContext(serializedHeaders)
 		if err == nil {
 			trace.traceID = prop.TraceID
@@ -62,6 +60,11 @@ func NewTrace(ctx context.Context, serializedHeaders string) (context.Context, *
 			}
 		}
 	}
+
+	if trace.traceID == "" {
+		trace.traceID = uuid.Must(uuid.NewRandom()).String()
+	}
+
 	rootSpan := newSpan()
 	rootSpan.isRoot = true
 	if trace.parentID != "" {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -362,6 +362,28 @@ func TestPropagatedFields(t *testing.T) {
 	assert.NotEqual(t, tr.parentID, tr2.parentID, "parent ID should have changed")
 	assert.Equal(t, tr.builder.Dataset, tr2.builder.Dataset, "dataset should have propagated")
 	assert.Equal(t, tr.traceLevelFields, tr2.traceLevelFields, "trace fields should have propagated")
+
+	prop = &propagation.Propagation{
+		Dataset: "imadataset",
+		TraceContext: map[string]interface{}{
+			"userID": float64(1),
+		},
+	}
+	serial = propagation.MarshalTraceContext(prop)
+	ctx, tr = NewTrace(context.Background(), serial)
+	assert.NotNil(t, tr.builder, "traces should have a builder")
+	assert.NotEqual(t, "", tr.traceID, "trace id should have propagated")
+	assert.Equal(t, "", tr.parentID, "parent id should have propagated")
+	assert.Equal(t, prop.Dataset, tr.builder.Dataset, "dataset should have propagated")
+	assert.Equal(t, prop.TraceContext, tr.traceLevelFields, "trace fields should have propagated")
+
+	ctx, tr = NewTrace(context.Background(), "garbage")
+	assert.NotNil(t, tr.builder, "traces should have a builder")
+	assert.NotEqual(t, "", tr.traceID, "trace id should have propagated")
+	assert.Equal(t, "", tr.parentID, "parent id should have propagated")
+	assert.Equal(t, "placeholder", tr.builder.Dataset, "dataset should have propagated")
+	assert.Equal(t, map[string]interface{}{}, tr.traceLevelFields, "trace fields should have propagated")
+
 }
 
 // BenchmarkSendChildSpans benchmarks creating and sending child spans in

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "0.3.5"
+const version = "0.3.6"


### PR DESCRIPTION
One real bugfix here: previously, if you handed NewTrace() a broken header, you'd end up with a trace with an empty traceID.

More controversially, I also allow partial propagation structs, which shouldn't actually occur with the current codebase. I think this is a safe change to make and actually lets me manually set the Dataset, which I was attempting with my previous change.