### PR TITLE
ev can't have been already sampled here so multiplying is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,53 @@ Release v0.4.1 (2019-03-21)
 
 * Sample rate returned by the sampler hook was incorrectly being multiplied with the default global sample rate.
 
+Release v0.4.0 (2018-11-28)
+==
+
+### Additions
+
+* Add a `libhoney.Client` as a configurable item in the beeline initial config.
+  This allows full control over the underlying transmission of spans, so you can
+  replace the HTTP transport or adjust queue sizes and so on
+
+Release v0.3.6 (2018-11-28)
+==
+
+### Additions
+
+* Add `CopyContext` function to simplify moving trace metadata to a new context
+  (for example, when trying to avoid a cancellation in an async span).
+* Improve handling of broken or partial trace propagation headers
+
+Release v0.3.5 (2018-11-28)
+==
+
+### Additions
+
+* Add `dataset` to serialized trace headers to allow one service with multiple
+  upstream callers to send spans to the right destination dataset
+
+Release v0.3.4 (2018-11-28)
+==
+
+### Additions
+
+* Delete spans from the trace when they're sent for improved memory management
+* Add a benchmark
+
+Release v0.3.3 (2018-11-28)
+==
+
+### Additions
+
+* Add URL queries and add name even when empty
+
 Release v0.3.2 (2018-11-28)
 ==
 
 ### Bugfixes
 
 * Fix multiple races when sending spans. (https://github.com/honeycombio/beeline-go/pull/39 and https://github.com/honeycombio/beeline-go/pull/40)
-
 
 Release v0.3.1 (2018-10-25)
 ==

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v0.4.1 (2019-03-21)
+==
+
+### Bugfixes
+
+* Sample rate returned by the sampler hook was incorrectly being multiplied with the default global sample rate.
+
 Release v0.3.2 (2018-11-28)
 ==
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -411,7 +411,7 @@ func (s *Span) send() {
 	if GlobalConfig.SamplerHook != nil {
 		var sampleRate int
 		shouldKeep, sampleRate = GlobalConfig.SamplerHook(s.ev.Fields())
-		s.ev.SampleRate *= uint(sampleRate)
+		s.ev.SampleRate = uint(sampleRate)
 	} else {
 		// use the default sampler
 		if sample.GlobalSampler != nil {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "0.4.0"
+const version = "0.4.1"


### PR DESCRIPTION
The multiplication of sample rate here is incorrect. It came from an assumption that `ev` could have already been sampled, but the code makes using a sampler hook an _alternative_ to the global sample rate, not in addition to it. Since sampling only happens once, the rates should not be multiplied.