### PR TITLE
Fix data race for children spans.

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -375,6 +375,7 @@ func (s *Span) send() {
 		s.AddField(k, v)
 	}
 
+	s.childrenLock.Lock()
 	// classify span type
 	var spanType string
 	switch {
@@ -391,6 +392,7 @@ func (s *Span) send() {
 	default:
 		spanType = "mid"
 	}
+	s.childrenLock.Unlock()
 	s.AddField("meta.span_type", spanType)
 
 	if spanType == "root" {


### PR DESCRIPTION
This patch makes sure that before checking how many children a span has; when calling `send()`; we will hold the `childrenLock` to avoid a data race if another goroutine is at the same time creating a new span and writing to `s.children`.

The lock is held here: https://github.com/honeycombio/beeline-go/blob/015109f8347c1922dcc0cc3b96d706c24fd96ef8/trace/trace.go#L438-L440

But when checking how many items the slice contains the lock is not held: https://github.com/honeycombio/beeline-go/blob/015109f8347c1922dcc0cc3b96d706c24fd96ef8/trace/trace.go#L389