### PR TITLE
Fix events not firing on a timer: add `BatchTimeout`

### DIFF
--- a/beeline.go
+++ b/beeline.go
@@ -70,18 +70,18 @@ type Config struct {
 	// environment.
 	Debug bool
 	// MaxBatchSize, if set, will override the default number of events
-	// (50) that are sent per batch.
+	// (libhoney.DefaultMaxBatchSize) that are sent per batch.
 	// Not used if client is set
 	MaxBatchSize uint
-	// BatchTimeout, if set, will override the default time (100 * time.Millisecond)
+	// BatchTimeout, if set, will override the default time (libhoney.DefaultBatchTimeout)
 	// for sending batches that have not been fully-filled.
 	// Not used if client is set
 	BatchTimeout time.Duration
 	// MaxConcurrentBatches, if set, will override the default number of
-	// goroutines (20) that are used to send batches of events in parallel.
+	// goroutines (libhoney.DefaultMaxConcurrentBatches) that are used to send batches of events in parallel.
 	// Not used if client is set
 	MaxConcurrentBatches uint
-	// PendingWorkCapacity overrides the default event queue size (1000).
+	// PendingWorkCapacity overrides the default event queue size (libhoney.DefaultPendingWorkCapacity).
 	// If the queue is full, events will be dropped.
 	// Not used if client is set
 	PendingWorkCapacity uint
@@ -105,16 +105,16 @@ func Init(config Config) {
 		config.SampleRate = defaultSampleRate
 	}
 	if config.MaxBatchSize == 0 {
-		config.MaxBatchSize = 50
+		config.MaxBatchSize = libhoney.DefaultMaxBatchSize
 	}
 	if config.BatchTimeout == 0 {
-		config.BatchTimeout = 100 * time.Millisecond
+		config.BatchTimeout = libhoney.DefaultBatchTimeout
 	}
 	if config.MaxConcurrentBatches == 0 {
-		config.MaxConcurrentBatches = 20
+		config.MaxConcurrentBatches = libhoney.DefaultMaxConcurrentBatches
 	}
 	if config.PendingWorkCapacity == 0 {
-		config.PendingWorkCapacity = 1000
+		config.PendingWorkCapacity = libhoney.DefaultPendingWorkCapacity
 	}
 	if config.Client == nil {
 		var tx transmission.Sender

--- a/beeline.go
+++ b/beeline.go
@@ -97,7 +97,7 @@ func Init(config Config) {
 		config.Dataset = defaultDataset
 	}
 	if config.SampleRate == 0 {
-		config.SampleRate = 1
+		config.SampleRate = defaultSampleRate
 	}
 	if config.MaxConcurrentBatches == 0 {
 		config.MaxConcurrentBatches = 20


### PR DESCRIPTION
This fixes #60 by adding a config option and default for `BatchTimeout` and passes it to `transmission.Honeycomb`.  If this is 0, `muster` doesn't send events on a timer: https://github.com/facebookarchive/muster/blob/master/muster.go#L65-L68

At the moment, there are 3 places that the `transmission.Honeycomb` struct is created:
- `beeline.Init` https://github.com/honeycombio/beeline-go/blob/master/beeline.go#L120-L125
- `libhoney.NewClient` https://github.com/honeycombio/libhoney-go/blob/master/client.go#L85-L93 (only if one is not passed in)
- `libhoney.Init` https://github.com/honeycombio/libhoney-go/blob/master/libhoney.go#L207-L218 (only if one is not passed in)

I considered trying to unify these, but I didn't want to introduce changes across both libraries, so opted for the more-minimal fix and just adding the config option in parallel with the existing ones.

I also found it surprising that the defaults for the existing batch settings were different between `beeline` and `libhoney`, so changed this to refer to the `libhoney` constants.  **This does change 2 of the defaults, though,** so if you'd rather not do this I can just pop off the last commit.