### PR TITLE
hnysqlx: Provide a method for accessing the inner DB

### DIFF
--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -47,7 +47,7 @@ func WrapDB(s *sqlx.DB) *DB {
 	return db
 }
 
-func (db *DB) WrappedDB() *sqlx.DB {
+func (db *DB) GetWrappedDB() *sqlx.DB {
 	return db.wdb
 }
 

--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -47,6 +47,10 @@ func WrapDB(s *sqlx.DB) *DB {
 	return db
 }
 
+func (db *DB) WrappedDB() *sqlx.DB {
+	return db.wdb
+}
+
 func (db *DB) Beginx() (*Tx, error) {
 	var err error
 	ev, sender := common.BuildDBEvent(db.Builder, "")


### PR DESCRIPTION
This can be useful when you want to use APIs that are not a part of the standard DB API.

In my specific case I want to use `pgx`'s `COPY FROM` support, which requires me to access the underlying `pgx` conn.