### PR TITLE
drop go1.9 tests, since deps have updated beyond it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ workflows:
   build:
     jobs:
       - test_beeline:
-          goversion: "9"
-      - test_beeline:
           goversion: "10"
       - test_beeline:
           goversion: "11"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ packages. Some of the dependencies have changed their API interface over the
 past few years (eg goji, uuid, net/http) so you may need to upgrade to get to a
 place that works.
 
-* **go 1.9+** - the context package moved into the core library and is used
+* **go 1.10+** - the context package moved into the core library and is used
   extensively by the beeline to make events available to the call stack
 * **github.com/google/uuid v0.2+** - the signature for NewRandom started returning
   `UUID, error`


### PR DESCRIPTION
It's totally conceivable that 1.9 still works if you have older pinned versions of our deps, but `go get` is fetching newer ones which don't even compile on 1.9.