### PR TITLE
[sqlx] functions with context should use spans; this one was skipped

### DIFF
--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -2082,7 +2082,7 @@ func (tx *Tx) Queryx(query string, args ...interface{}) (*sqlx.Rows, error) {
 
 func (tx *Tx) QueryxContext(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
 	var err error
-	_, sender := common.BuildDBEvent(tx.Builder, query, args...)
+	_, sender := common.BuildDBSpan(ctx, tx.Builder, query, args...)
 	defer func() {
 		sender(err)
 	}()

--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -2082,7 +2082,7 @@ func (tx *Tx) Queryx(query string, args ...interface{}) (*sqlx.Rows, error) {
 
 func (tx *Tx) QueryxContext(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
 	var err error
-	_, sender := common.BuildDBSpan(ctx, tx.Builder, query, args...)
+	ctx, _, sender := common.BuildDBSpan(ctx, tx.Builder, query, args...)
 	defer func() {
 		sender(err)
 	}()


### PR DESCRIPTION
All the functions that get context are supposed to use that context to join the events created to existing traces as spans. Functions that don't have context use the event-version of the instrumentation instead.

This instances of the QueryxContext function accidentally used the event version instead of the span version.  This change fixes that error.