### PR TITLE
[sqlx] Adding an error interface does not stringify by default. Explicitly use the error string

### DIFF
--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -164,7 +164,7 @@ func BuildDBEvent(bld *libhoney.Builder, stats sql.DBStats, query string, args .
 		// rollup(ctx, ev, duration)
 		ev.AddField("duration_ms", duration)
 		if err != nil {
-			ev.AddField("db.error", err)
+			ev.AddField("db.error", err.Error())
 		}
 		ev.Metadata, _ = ev.Fields()["name"]
 		ev.Send()
@@ -199,7 +199,7 @@ func BuildDBSpan(ctx context.Context, bld *libhoney.Builder, stats sql.DBStats, 
 	fn := func(err error) {
 		duration := timer.Finish()
 		if err != nil {
-			span.AddField("db.error", err)
+			span.AddField("db.error", err.Error())
 		}
 		span.AddRollupField("db.duration_ms", duration)
 		span.AddRollupField("db.call_count", 1)

--- a/wrappers/hnysqlx/sqlx.go
+++ b/wrappers/hnysqlx/sqlx.go
@@ -261,7 +261,7 @@ func (db *DB) MustBegin() *Tx {
 	wrapTx.wtx = tx
 
 	if err != nil {
-		ev.AddField("db.panic", err)
+		ev.AddField("db.panic", err.Error())
 		panic(err)
 	}
 	return wrapTx
@@ -304,7 +304,7 @@ func (db *DB) MustBeginTx(ctx context.Context, opts *sql.TxOptions) *Tx {
 	// manually wrap the panic in order to report it
 	if err != nil {
 		if span != nil {
-			span.AddField("db.panic", err)
+			span.AddField("db.panic", err.Error())
 		}
 		panic(err)
 	}
@@ -328,7 +328,7 @@ func (db *DB) MustExec(query string, args ...interface{}) sql.Result {
 
 	// manually wrap the panic in order to report it
 	if err != nil {
-		ev.AddField("db.panic", err)
+		ev.AddField("db.panic", err.Error())
 		panic(err)
 	}
 
@@ -363,7 +363,7 @@ func (db *DB) MustExecContext(ctx context.Context, query string, args ...interfa
 	// manually wrap the panic in order to report it
 	if err != nil {
 		if span != nil {
-			span.AddField("db.panic", err)
+			span.AddField("db.panic", err.Error())
 		}
 		panic(err)
 	}
@@ -1025,7 +1025,7 @@ func (n *NamedStmt) MustExec(arg interface{}) sql.Result {
 
 	// manually wrap the panic in order to report it
 	if err != nil {
-		ev.AddField("db.panic", err)
+		ev.AddField("db.panic", err.Error())
 		panic(err)
 	}
 
@@ -1054,7 +1054,7 @@ func (n *NamedStmt) MustExecContext(ctx context.Context, arg interface{}) sql.Re
 	// manually wrap the panic in order to report it
 	if err != nil {
 		if span != nil {
-			span.AddField("db.panic", err)
+			span.AddField("db.panic", err.Error())
 		}
 		panic(err)
 	}
@@ -1277,7 +1277,7 @@ func (s *Stmt) MustExec(args ...interface{}) sql.Result {
 
 	// manually wrap the panic in order to report it
 	if err != nil {
-		ev.AddField("db.panic", err)
+		ev.AddField("db.panic", err.Error())
 		panic(err)
 	}
 
@@ -1311,7 +1311,7 @@ func (s *Stmt) MustExecContext(ctx context.Context, args ...interface{}) sql.Res
 	// manually wrap the panic in order to report it
 	if err != nil {
 		if span != nil {
-			span.AddField("db.panic", err)
+			span.AddField("db.panic", err.Error())
 		}
 		panic(err)
 	}
@@ -1662,7 +1662,7 @@ func (tx *Tx) MustExec(query string, args ...interface{}) sql.Result {
 
 	// manually wrap the panic in order to report it
 	if err != nil {
-		ev.AddField("db.panic", err)
+		ev.AddField("db.panic", err.Error())
 		panic(err)
 	}
 
@@ -1696,7 +1696,7 @@ func (tx *Tx) MustExecContext(ctx context.Context, query string, args ...interfa
 	// manually wrap the panic in order to report it
 	if err != nil {
 		if span != nil {
-			span.AddField("db.panic", err)
+			span.AddField("db.panic", err.Error())
 		}
 		panic(err)
 	}


### PR DESCRIPTION
When adding an `error` type to a span, the effect is that you get the JSON serialized version of an interface type which is `{}`. This is not super useful. This change explicitly asks for the string representation of the error instead of throwing in the error type, resulting in better content in the error field.