### PR TITLE
Add ability to extract arbitrary request headers as properties

### DIFF
--- a/wrappers/common/common_test.go
+++ b/wrappers/common/common_test.go
@@ -56,6 +56,24 @@ func TestXForwardedProtoHeader(t *testing.T) {
 	assert.Equal(t, xForwardedProto, props["request.header.x_forwarded_proto"])
 }
 
+func TestRefererHeader(t *testing.T) {
+	referer := "http://example.com/foo"
+	req := httptest.NewRequest("GET", "https://unused.com/", nil)
+	req.Header.Set("Referer", referer)
+	props := GetRequestProps(req)
+	assert.Equal(t, referer, props["request.header.referer"])
+}
+
+func TestExtractCustomHeader(t *testing.T) {
+	customHeaderName := "X-Custom-Header"
+	customHeaderVal := "foo"
+	ExtractCustomHeaders = []string{customHeaderName}
+	req := httptest.NewRequest("GET", "https://unused.com/", nil)
+	req.Header.Set(customHeaderName, customHeaderVal)
+	props := GetRequestProps(req)
+	assert.Equal(t, customHeaderVal, props["request.header.x_custom_header"])
+}
+
 // TestSharedDBEvent verifies that the name field is set to something
 func TestSharedDBEvent(t *testing.T) {
 	bld := libhoney.NewBuilder()

--- a/wrappers/hnyecho/echo.go
+++ b/wrappers/hnyecho/echo.go
@@ -7,6 +7,10 @@ import (
 	"github.com/labstack/echo"
 )
 
+var (
+	ExtractCustomHeaders []string
+)
+
 // EchoWrapper provides Honeycomb instrumentation for the Echo router via middleware
 type (
 	EchoWrapper struct {
@@ -22,6 +26,7 @@ func New() *EchoWrapper {
 
 // Middleware returns an echo.MiddlewareFunc to be used with Echo.Use()
 func (e *EchoWrapper) Middleware() echo.MiddlewareFunc {
+	common.ExtractCustomHeaders = ExtractCustomHeaders
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			r := c.Request()

--- a/wrappers/hnygoji/goji.go
+++ b/wrappers/hnygoji/goji.go
@@ -11,9 +11,14 @@ import (
 	"goji.io/pat"
 )
 
+var (
+	ExtractCustomHeaders []string
+)
+
 // Middleware is specifically to use with goji's router.Use() function for
 // inserting middleware
 func Middleware(handler http.Handler) http.Handler {
+	common.ExtractCustomHeaders = ExtractCustomHeaders
 	wrappedHandler := func(w http.ResponseWriter, r *http.Request) {
 		// get a new context with our trace from the request, and add common fields
 		ctx, span := common.StartSpanOrTraceFromHTTP(r)

--- a/wrappers/hnygorilla/gorilla.go
+++ b/wrappers/hnygorilla/gorilla.go
@@ -9,9 +9,14 @@ import (
 	"github.com/honeycombio/beeline-go/wrappers/common"
 )
 
+var (
+	ExtractCustomHeaders []string
+)
+
 // Middleware is a gorilla middleware to add Honeycomb instrumentation to the
 // gorilla muxer.
 func Middleware(handler http.Handler) http.Handler {
+	common.ExtractCustomHeaders = ExtractCustomHeaders
 	wrappedHandler := func(w http.ResponseWriter, r *http.Request) {
 		// get a new context with our trace from the request, and add common fields
 		ctx, span := common.StartSpanOrTraceFromHTTP(r)

--- a/wrappers/hnyhttprouter/httprouter.go
+++ b/wrappers/hnyhttprouter/httprouter.go
@@ -9,9 +9,14 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+var (
+	ExtractCustomHeaders []string
+)
+
 // Middleware wraps httprouter handlers. Since it wraps handlers with explicit
 // parameters, it can add those values to the event it generates.
 func Middleware(handle httprouter.Handle) httprouter.Handle {
+	common.ExtractCustomHeaders = ExtractCustomHeaders
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		// get a new context with our trace from the request, and add common fields
 		ctx, span := common.StartSpanOrTraceFromHTTP(r)

--- a/wrappers/hnynethttp/nethttp.go
+++ b/wrappers/hnynethttp/nethttp.go
@@ -13,12 +13,17 @@ import (
 	libhoney "github.com/honeycombio/libhoney-go"
 )
 
+var (
+	ExtractCustomHeaders []string
+)
+
 // WrapHandler will create a Honeycomb event per invocation of this handler with
 // all the standard HTTP fields attached. If passed a ServeMux instead, pull
 // what you can from there
 func WrapHandler(handler http.Handler) http.Handler {
 	// if we can cache handlerName here, let's do so for efficiency's sake
 	handlerName := runtime.FuncForPC(reflect.ValueOf(handler).Pointer()).Name()
+	common.ExtractCustomHeaders = ExtractCustomHeaders
 
 	wrappedHandler := func(w http.ResponseWriter, r *http.Request) {
 		// get a new context with our trace from the request, and add common fields
@@ -73,6 +78,7 @@ func WrapHandler(handler http.Handler) http.Handler {
 // function with all the standard HTTP fields attached.
 func WrapHandlerFunc(hf func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
 	handlerFuncName := runtime.FuncForPC(reflect.ValueOf(hf).Pointer()).Name()
+	common.ExtractCustomHeaders = ExtractCustomHeaders
 	return func(w http.ResponseWriter, r *http.Request) {
 		// get a new context with our trace from the request, and add common fields
 		ctx, span := common.StartSpanOrTraceFromHTTP(r)


### PR DESCRIPTION
- add the referer header (if present) by default
- allow setting ExtractCustomHeaders to a list of header names