### PR TITLE
Replace UUID strings with W3C Trace Context compatible IDs.

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -45,8 +45,8 @@ type Trace struct {
 	traceLevelFields map[string]interface{}
 }
 
-// getNewID generates a hex encoded string with the specified number of bytes.
-// It is used for ID generation for traces and spans.
+// getNewID generates a lowercase hex encoded string with the specified number
+// of bytes. It is used for ID generation for traces and spans.
 func getNewID(length uint16) string {
 	id := make([]byte, length)
 	// rand.Seed is called in libhoney's init, so this is sure to have well-seeded random content.

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -49,6 +49,7 @@ type Trace struct {
 // It is used for ID generation for traces and spans.
 func getNewID(length uint16) string {
 	id := make([]byte, length)
+	// rand.Seed is called in libhoney's init, so this is sure to have well-seeded random content.
 	_, _ = rand.Read(id)
 	return hex.EncodeToString(id)
 }

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -2,7 +2,9 @@ package trace
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -411,6 +413,17 @@ func TestPropagatedFields(t *testing.T) {
 	assert.Equal(t, "placeholder", tr.builder.Dataset, "dataset should have propagated")
 	assert.Equal(t, map[string]interface{}{}, tr.traceLevelFields, "trace fields should have propagated")
 
+}
+
+// TestGetNewID ensures that ID is always a lowercase hex string of the requested length
+func TestGetNewID(t *testing.T) {
+	id := getNewID(8)
+	assert.Equal(t, 16, len(id), "an 8 byte array should produce a 32 bit hex string")
+	assert.Equal(t, strings.ToLower(id), id, "ids should be lowercase")
+	decoded, err := hex.DecodeString(id)
+	if assert.NoError(t, err) {
+		assert.Equal(t, hex.EncodeToString(decoded), id, "ids should be hex encoded")
+	}
 }
 
 // BenchmarkSendChildSpans benchmarks creating and sending child spans in


### PR DESCRIPTION
The [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification defines span ids as 8-byte arrays and trace ids as 16-byte arrays. In order to maintain compatibility with other services using that standard, we should start generating our ids in the same way. This will make it easier to add trace propagation interoperability between OpenTelemetry and Beeline instrumented services.

This is part of a series of PRs meant to replace #108.