### PR TITLE
Generalize PropagationContext and Related Methods

### DIFF
--- a/propagation/honeycomb.go
+++ b/propagation/honeycomb.go
@@ -65,7 +65,7 @@ func UnmarshalHoneycombTraceContext(header string) (*PropagationContext, error) 
 	// pull the version out of the header
 	getVer := strings.SplitN(header, ";", 2)
 	if getVer[0] == "1" {
-		return UnmarshalTraceContextV1(getVer[1])
+		return UnmarshalHoneycombTraceContextV1(getVer[1])
 	}
 	return nil, &PropagationError{fmt.Sprintf("unrecognized version for trace header %s", getVer[0]), nil}
 }

--- a/propagation/honeycomb.go
+++ b/propagation/honeycomb.go
@@ -1,0 +1,105 @@
+package propagation
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// assumes a header of the form:
+
+// VERSION;PAYLOAD
+
+// VERSION=1
+// =========
+// PAYLOAD is a list of comma-separated params (k=v pairs), with no spaces.  recognized
+// keys + value types:
+//
+//  trace_id=${traceId}    - traceId is an opaque ascii string which shall not include ','
+//  parent_id=${spanId}    - spanId is an opaque ascii string which shall not include ','
+//  dataset=${datasetId}   - datasetId is the slug for the honeycomb dataset to which downstream spans should be sent; shall not include ','
+//  context=${contextBlob} - contextBlob is a base64 encoded json object.
+//
+// ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
+
+const (
+	TracePropagationHTTPHeader = "X-Honeycomb-Trace"
+	TracePropagationVersion    = 1
+)
+
+// MarshalHoneycombTraceContext uses the information in prop to create a trace context header
+// in the Honeycomb trace header format. It returns the header and header name as a key value
+// pair in a map.
+func MarshalHoneycombTraceContext(prop *PropagationContext) string {
+	tcJSON, err := json.Marshal(prop.TraceContext)
+	if err != nil {
+		// if we couldn't marshal the trace level fields, leave it blank
+		tcJSON = []byte("")
+	}
+
+	tcB64 := base64.StdEncoding.EncodeToString(tcJSON)
+
+	var datasetClause string
+	if prop.Dataset != "" {
+		datasetClause = fmt.Sprintf("dataset=%s,", url.QueryEscape(prop.Dataset))
+	}
+
+	return fmt.Sprintf(
+		"%d;trace_id=%s,parent_id=%s,%scontext=%s",
+		TracePropagationVersion,
+		prop.TraceID,
+		prop.ParentID,
+		datasetClause,
+		tcB64,
+	)
+}
+
+// UnmarshalHoneycombTraceContext parses the information provided in header and creates a
+// PropagationContext instance.
+func UnmarshalHoneycombTraceContext(header string) (*PropagationContext, error) {
+	// pull the version out of the header
+	getVer := strings.SplitN(header, ";", 2)
+	if getVer[0] == "1" {
+		return UnmarshalTraceContextV1(getVer[1])
+	}
+	return nil, &PropagationError{fmt.Sprintf("unrecognized version for trace header %s", getVer[0]), nil}
+}
+
+// UnmarshalHoneycombTraceContextV1 takes the trace header, stripped of the
+// version string, and returns the component parts. Trace ID and Parent ID
+// are both required. If either is absent a nil trace header will be returned.
+func UnmarshalHoneycombTraceContextV1(header string) (*PropagationContext, error) {
+	clauses := strings.Split(header, ",")
+	var prop = &PropagationContext{}
+	var tcB64 string
+	for _, clause := range clauses {
+		keyval := strings.SplitN(clause, "=", 2)
+		switch keyval[0] {
+		case "trace_id":
+			prop.TraceID = keyval[1]
+		case "parent_id":
+			prop.ParentID = keyval[1]
+		case "dataset":
+			prop.Dataset, _ = url.QueryUnescape(keyval[1])
+		case "context":
+			tcB64 = keyval[1]
+		}
+	}
+	if prop.TraceID == "" && prop.ParentID != "" {
+		return nil, &PropagationError{"parent_id without trace_id", nil}
+	}
+	if tcB64 != "" {
+		data, err := base64.StdEncoding.DecodeString(tcB64)
+		if err != nil {
+			return nil, &PropagationError{"unable to decode base64 trace context", err}
+		}
+		prop.TraceContext = make(map[string]interface{})
+		err = json.Unmarshal(data, &prop.TraceContext)
+		if err != nil {
+			return nil, &PropagationError{"unable to unmarshal trace context", err}
+		}
+	}
+	return prop, nil
+}

--- a/propagation/honeycomb.go
+++ b/propagation/honeycomb.go
@@ -33,6 +33,9 @@ const (
 // in the Honeycomb trace header format. It returns the serialized form of the trace context, 
 // ready to be inserted into the headers of an outbound HTTP request.
 func MarshalHoneycombTraceContext(prop *PropagationContext) string {
+	if prop == nil {
+		return ""
+	}
 	tcJSON, err := json.Marshal(prop.TraceContext)
 	if err != nil {
 		// if we couldn't marshal the trace level fields, leave it blank

--- a/propagation/honeycomb.go
+++ b/propagation/honeycomb.go
@@ -30,8 +30,8 @@ const (
 )
 
 // MarshalHoneycombTraceContext uses the information in prop to create a trace context header
-// in the Honeycomb trace header format. It returns the header and header name as a key value
-// pair in a map.
+// in the Honeycomb trace header format. It returns the serialized form of the trace context, 
+// ready to be inserted into the headers of an outbound HTTP request.
 func MarshalHoneycombTraceContext(prop *PropagationContext) string {
 	tcJSON, err := json.Marshal(prop.TraceContext)
 	if err != nil {

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 )
 
-// Default to using the Honeycomb Trace Context header.
-const defaultTracePropagationHTTPHeader = TracePropagationHTTPHeader
-
 // PropagationContext contains information about a trace that can cross process boundaries.
 // Typically this information is parsed from an incoming trace context header.
 type PropagationContext struct {

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -1,46 +1,35 @@
 package propagation
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"net/url"
-	"strings"
 )
 
-// assumes a header of the form:
+// Default to using the Honeycomb Trace Context header.
+const defaultTracePropagationHTTPHeader = TracePropagationHTTPHeader
 
-// VERSION;PAYLOAD
-
-// VERSION=1
-// =========
-// PAYLOAD is a list of comma-separated params (k=v pairs), with no spaces.  recognized
-// keys + value types:
-//
-//  trace_id=${traceId}    - traceId is an opaque ascii string which shall not include ','
-//  parent_id=${spanId}    - spanId is an opaque ascii string which shall not include ','
-//  dataset=${datasetId}   - datasetId is the slug for the honeycomb dataset to which downstream spans should be sent; shall not include ','
-//  context=${contextBlob} - contextBlob is a base64 encoded json object.
-//
-// ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
-
-const (
-	TracePropagationHTTPHeader = "X-Honeycomb-Trace"
-	TracePropagationVersion    = 1
-)
-
-type Propagation struct {
+// PropagationContext contains information about a trace that can cross process boundaries.
+// Typically this information is parsed from an incoming trace context header.
+type PropagationContext struct {
 	TraceID      string
 	ParentID     string
 	Dataset      string
 	TraceContext map[string]interface{}
+	TraceFlags   byte
 }
 
+// Propagation contains information about a trace.
+//
+// Deprecated: use PropagationContext instead.
+type Propagation = PropagationContext
+
+// PropagationError wraps any error encountered while parsing or serializing trace propagation
+// contexts.
 type PropagationError struct {
 	message      string
 	wrappedError error
 }
 
+// Error returns a formatted message containing the error.
 func (p *PropagationError) Error() string {
 	if p.wrappedError == nil {
 		return p.message
@@ -48,72 +37,23 @@ func (p *PropagationError) Error() string {
 	return fmt.Sprintf(p.message, p.wrappedError)
 }
 
-func MarshalTraceContext(prop *Propagation) string {
-	tcJSON, err := json.Marshal(prop.TraceContext)
-	if err != nil {
-		// if we couldn't marshal the trace level fields, leave it blank
-		tcJSON = []byte("")
-	}
-
-	tcB64 := base64.StdEncoding.EncodeToString(tcJSON)
-
-	var datasetClause string
-	if prop.Dataset != "" {
-		datasetClause = fmt.Sprintf("dataset=%s,", url.QueryEscape(prop.Dataset))
-	}
-
-	return fmt.Sprintf(
-		"%d;trace_id=%s,parent_id=%s,%scontext=%s",
-		TracePropagationVersion,
-		prop.TraceID,
-		prop.ParentID,
-		datasetClause,
-		tcB64,
-	)
+// MarshalTraceContext wraps MarshalHoneycombTraceContext for backwards compatibility.
+//
+// Deprecated: Use MarshalHoneycombTraceContext.
+func MarshalTraceContext(prop *PropagationContext) string {
+	return MarshalHoneycombTraceContext(prop)
 }
 
-func UnmarshalTraceContext(header string) (*Propagation, error) {
-	// pull the version out of the header
-	getVer := strings.SplitN(header, ";", 2)
-	if getVer[0] == "1" {
-		return UnmarshalTraceContextV1(getVer[1])
-	}
-	return nil, &PropagationError{fmt.Sprintf("unrecognized version for trace header %s", getVer[0]), nil}
+// UnmarshalTraceContext wraps UnmarshalHoneycombTraceContext for backwards compatibility.
+//
+// Deprecated: Use UnmarshalHoneycombTraceContext
+func UnmarshalTraceContext(header string) (*PropagationContext, error) {
+	return UnmarshalHoneycombTraceContext(header)
 }
 
-// UnmarshalTraceContextV1 takes the trace header, stripped of the version
-// string, and returns the component parts. Trace ID and Parent ID are both
-// required. If either is absent a nil trace header will be returned.
-func UnmarshalTraceContextV1(header string) (*Propagation, error) {
-	clauses := strings.Split(header, ",")
-	var prop = &Propagation{}
-	var tcB64 string
-	for _, clause := range clauses {
-		keyval := strings.SplitN(clause, "=", 2)
-		switch keyval[0] {
-		case "trace_id":
-			prop.TraceID = keyval[1]
-		case "parent_id":
-			prop.ParentID = keyval[1]
-		case "dataset":
-			prop.Dataset, _ = url.QueryUnescape(keyval[1])
-		case "context":
-			tcB64 = keyval[1]
-		}
-	}
-	if prop.TraceID == "" && prop.ParentID != "" {
-		return nil, &PropagationError{"parent_id without trace_id", nil}
-	}
-	if tcB64 != "" {
-		data, err := base64.StdEncoding.DecodeString(tcB64)
-		if err != nil {
-			return nil, &PropagationError{"unable to decode base64 trace context", err}
-		}
-		prop.TraceContext = make(map[string]interface{})
-		err = json.Unmarshal(data, &prop.TraceContext)
-		if err != nil {
-			return nil, &PropagationError{"unable to unmarshal trace context", err}
-		}
-	}
-	return prop, nil
+// UnmarshalTraceContextV1 wraps UnmarshalHoneycombTraceContextV1 for backwards compatibility.
+//
+// Deprecated: Use UnmarshalHoneycombTraceContext. Do not call this function directly.
+func UnmarshalTraceContextV1(header string) (*PropagationContext, error) {
+	return UnmarshalHoneycombTraceContextV1(header)
 }

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestMarshalTraceContext(t *testing.T) {
-	prop := &Propagation{
+	prop := &PropagationContext{
 		TraceID:  "abcdef123456",
 		ParentID: "0102030405",
 		TraceContext: map[string]interface{}{
@@ -43,7 +43,7 @@ func TestMarshalTraceContext(t *testing.T) {
 	assert.Equal(t, prop, returned, "roundtrip object")
 	assert.NoError(t, err, "roundtrip error")
 
-	prop = &Propagation{
+	prop = &PropagationContext{
 		Dataset: "imadataset",
 	}
 	marshaled = MarshalTraceContext(prop)
@@ -59,7 +59,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 	testCases := []struct {
 		name       string
 		contextStr string
-		prop       *Propagation
+		prop       *PropagationContext
 		returnsErr bool
 	}{
 		{
@@ -71,7 +71,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 		{
 			"v1 trace_id + parent_id, missing context",
 			"1;trace_id=abcdef,parent_id=12345",
-			&Propagation{
+			&PropagationContext{
 				TraceID:  "abcdef",
 				ParentID: "12345",
 			},
@@ -80,7 +80,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 		{
 			"v1, all headers and legit context",
 			"1;trace_id=abcdef,parent_id=12345,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==",
-			&Propagation{
+			&PropagationContext{
 				TraceID:  "abcdef",
 				ParentID: "12345",
 				TraceContext: map[string]interface{}{
@@ -100,7 +100,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 		{
 			"v1, missing parent_id",
 			"1;trace_id=12345",
-			&Propagation{
+			&PropagationContext{
 				TraceID: "12345",
 			},
 			false,
@@ -114,7 +114,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 		{
 			"v1, unknown key (otherwise valid)",
 			"1;trace_id=abcdef,parent_id=12345,something=unsupported",
-			&Propagation{
+			&PropagationContext{
 				TraceID:  "abcdef",
 				ParentID: "12345",
 			},
@@ -123,7 +123,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 		{
 			"v1, extra unknown key (otherwise valid)",
 			"1;trace_id=abcdef,parent_id=12345,something=unsupported,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==",
-			&Propagation{
+			&PropagationContext{
 				TraceID:  "abcdef",
 				ParentID: "12345",
 				TraceContext: map[string]interface{}{

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -115,7 +115,7 @@ func (t *Trace) AddField(key string, val interface{}) {
 // The serialized form may be passed to NewTrace() in order to create a new
 // trace that will be connected to this trace.
 func (t *Trace) serializeHeaders(spanID string) string {
-	var prop = &propagation.Propagation{
+	var prop = &propagation.PropagationContext{
 		TraceID:      t.traceID,
 		ParentID:     spanID,
 		Dataset:      t.builder.Dataset,

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -364,7 +364,7 @@ func TestAddFieldDoesNotCauseRaceInSendHooks(t *testing.T) {
 }
 
 func TestPropagatedFields(t *testing.T) {
-	prop := &propagation.Propagation{
+	prop := &propagation.PropagationContext{
 		TraceID:  "abcdef123456",
 		ParentID: "0102030405",
 		Dataset:  "imadataset",
@@ -392,7 +392,7 @@ func TestPropagatedFields(t *testing.T) {
 	assert.Equal(t, tr.builder.Dataset, tr2.builder.Dataset, "dataset should have propagated")
 	assert.Equal(t, tr.traceLevelFields, tr2.traceLevelFields, "trace fields should have propagated")
 
-	prop = &propagation.Propagation{
+	prop = &propagation.PropagationContext{
 		Dataset: "imadataset",
 		TraceContext: map[string]interface{}{
 			"userID": float64(1),

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -60,6 +60,44 @@ func TestNewTrace(t *testing.T) {
 	})
 }
 
+// TestNewTraceFromPropagationContext creates traces using data in a struct and
+// makes sure they're populated with all the things we want.
+func TestNewTraceFromPropagationContext(t *testing.T) {
+	ctx, tr := NewTraceFromPropagationContext(context.Background(), nil)
+	assert.NotNil(t, tr.builder, "traces should have a builder")
+	assert.NotEmpty(t, tr.traceID, "trace should have a trace ID")
+	assert.Empty(t, tr.parentID, "trace created with no propagation context should have an empty parent ID")
+	assert.NotNil(t, tr.rollupFields, "trace should initialize rollup fields map")
+	assert.NotNil(t, tr.rootSpan, "trace should have a root span")
+	assert.NotNil(t, tr.traceLevelFields, "trace should initialize trace level fields map")
+	trFromContext := GetTraceFromContext(ctx)
+	assert.Equal(t, tr, trFromContext, "new trace should put the trace in the context")
+	spFromContext := GetSpanFromContext(ctx)
+	assert.Equal(t, tr.rootSpan, spFromContext, "new trace should put the root span in the context")
+
+	// create a trace with a propagationcontext and make sure that the
+	// appropriate fields are populated. A propagation context object
+	// contains a trace id, parent id, optional trace context and an
+	// optional dataset. There is also a TraceFlags field, but that isn't
+	// being parsed yet.
+	prop := &propagation.PropagationContext{
+		TraceID:  "0af7651916cd43dd8448eb211c80319c",
+		ParentID: "00f067aa0ba902b7",
+		Dataset:  "my-dataset",
+		TraceContext: map[string]interface{}{
+			"userID":   1,
+			"errorMsg": "failed to sign on",
+			"toRetry":  true,
+		},
+	}
+	_, tr = NewTraceFromPropagationContext(ctx, prop)
+	assert.Equal(t, "0af7651916cd43dd8448eb211c80319c", tr.traceID, "trace with a propagation context should take trace ID")
+	assert.Equal(t, "00f067aa0ba902b7", tr.parentID, "trace with a propagation context should take parent ID")
+	assert.Equal(t, int(1), tr.traceLevelFields["userID"], "trace with a propagation context should populate trace level fields")
+	assert.Equal(t, "failed to sign on", tr.traceLevelFields["errorMsg"], "trace with a propagation context should populate trace level fields")
+	assert.Equal(t, true, tr.traceLevelFields["toRetry"], "trace with a propagation context should populate trace level fields")
+}
+
 // TestAddField tests adding a field to a trace
 func TestAddField(t *testing.T) {
 	_, tr := NewTrace(context.Background(), "")


### PR DESCRIPTION
In preparation for adding support for different trace propagation wire formats, this PR generalizes PropagationContext to include fields found in all of the formats we plan to support. It also renames generic functions like `MarshalTraceContext` to the more specific `MarshalHoneycombTraceContext`. (In future PRs we plan to introduce marshal / unmarshal functions for other trace header formats). The old function names are left as wrappers and are marked as deprecated.

This also adds a `NewTraceFromPropagationContext` function to the `trace` package. This function will be used to create traces from newly parsed headers but, unlike `NewTraceFromSerializedHeaders`, has no knowledge of the header format itself. `NewTrace` wraps `NewTraceFromSerializedHeaders` but may in the future change to wrap `NewTraceFromPropagationContext`.

Looking for 👀 from @maplebed. Tagging @katiebayes and @dsoo as an FYI and for additional 👀 but not required.