### PR TITLE
Create trace parser and propagation hooks.

### DIFF
--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -36,7 +36,7 @@ func TestPropagationContextIsValid(t *testing.T) {
 	// a propagation context is valid when it has a parent id and a trace id
 	prop = &PropagationContext{
 		ParentID: "parent_id",
-		TraceID: "trace_id",
+		TraceID:  "trace_id",
 	}
 	assert.True(t, prop.IsValid())
 
@@ -45,7 +45,7 @@ func TestPropagationContextIsValid(t *testing.T) {
 	var traceID [16]byte
 	prop = &PropagationContext{
 		ParentID: hex.EncodeToString(spanID[:]),
-		TraceID: hex.EncodeToString(traceID[:]),
+		TraceID:  hex.EncodeToString(traceID[:]),
 	}
 	assert.Equal(t, false, prop.IsValid())
 }
@@ -295,8 +295,8 @@ func TestUnmarshalAmazonTraceContext(t *testing.T) {
 			"self, parent and root fields. parent should end up in trace context",
 			"Root=foo;Parent=bar;Self=baz",
 			&PropagationContext{
-				TraceID:      "foo",
-				ParentID:     "baz",
+				TraceID:  "foo",
+				ParentID: "baz",
 				TraceContext: map[string]interface{}{
 					"Parent": "bar",
 				},
@@ -307,8 +307,8 @@ func TestUnmarshalAmazonTraceContext(t *testing.T) {
 			"self, parent and root fields. parent should end up in trace context",
 			"Root=foo;Self=baz;Parent=bar",
 			&PropagationContext{
-				TraceID:      "foo",
-				ParentID:     "baz",
+				TraceID:  "foo",
+				ParentID: "baz",
 				TraceContext: map[string]interface{}{
 					"Parent": "bar",
 				},

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -504,3 +504,14 @@ func (s *Span) createChildSpan(ctx context.Context, async bool) (context.Context
 	ctx = PutSpanInContext(ctx, newSpan)
 	return ctx, newSpan
 }
+
+// PropagationContext creates and returns a new propagation.PropagationContext using the
+// information in the current span.
+func (s *Span) PropagationContext() *propagation.PropagationContext {
+	return &propagation.PropagationContext{
+		TraceID:	  s.trace.traceID,
+		ParentID:	  s.spanID,
+		Dataset:	  s.trace.builder.Dataset,
+		TraceContext: s.trace.traceLevelFields,
+	}
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -509,9 +509,9 @@ func (s *Span) createChildSpan(ctx context.Context, async bool) (context.Context
 // information in the current span.
 func (s *Span) PropagationContext() *propagation.PropagationContext {
 	return &propagation.PropagationContext{
-		TraceID:	  s.trace.traceID,
-		ParentID:	  s.spanID,
-		Dataset:	  s.trace.builder.Dataset,
+		TraceID:      s.trace.traceID,
+		ParentID:     s.spanID,
+		Dataset:      s.trace.builder.Dataset,
 		TraceContext: s.trace.traceLevelFields,
 	}
 }

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -431,9 +431,9 @@ func TestPropagatedFields(t *testing.T) {
 	assert.Equal(t, tr.traceLevelFields, tr2.traceLevelFields, "trace fields should have propagated")
 
 	prop = &propagation.PropagationContext{
-		TraceID: "trace id",
+		TraceID:  "trace id",
 		ParentID: "parent id",
-		Dataset: "imadataset",
+		Dataset:  "imadataset",
 		TraceContext: map[string]interface{}{
 			"userID": float64(1),
 		},

--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -11,29 +11,9 @@ import (
 	"github.com/honeycombio/beeline-go/propagation"
 	"github.com/honeycombio/beeline-go/timer"
 	"github.com/honeycombio/beeline-go/trace"
+	"github.com/honeycombio/beeline-go/wrappers/config"
 	libhoney "github.com/honeycombio/libhoney-go"
 )
-
-// TraceParserHook is a function that will be invoked on all incoming HTTP requests
-// when it is passed as a parameter to an http.Handler wrapper function such as the
-// one provided in the hnynethttp package. It can be used to create a PropagationContext
-// object using trace context propagation headers in the provided http.Request. It is
-// expected that this hook will use one of the unmarshal functions exported in the
-// propagation package for a number of supported formats (e.g. Honeycomb, AWS,
-// W3C Trace Context, etc).
-type TraceParserHook func(*http.Request) *propagation.PropagationContext
-
-// TracePropagationHook is a function that will be invoked on all outgoing HTTP requests
-// when it is passed as a parameter to a RoundTripper wrapper function such as the one
-// provided in the hnynethttp package. It can be used to create a map of header names
-// to header values that will be injected in the outgoing request. The information in
-// the provided http.Request can be used to make decisions about what headers to include
-// in the outgoing request, for example based on the hostname of the target of the request.
-// The information in the provided PropagationContext should be used to create the serialized
-// header values. It is expected that this hook will use one of the marshal functions exported
-// in the propagation package for a number of supported formats (e.g. Honeycomb, AWS,
-// W3C Trace Context, etc).
-type TracePropagationHook func(*http.Request, *propagation.PropagationContext) map[string]string
 
 type ResponseWriter struct {
 	// Wrapped is not embedded to prevent ResponseWriter from directly
@@ -74,7 +54,7 @@ func StartSpanOrTraceFromHTTP(r *http.Request) (context.Context, *trace.Span) {
 // StartSpanOrTraceFromHTTPWithTraceParserHook is a version of StartSpanOrTraceFromHTTP that
 // accepts a TraceParserHook which will be invoked when creating a new trace for the incoming
 // HTTP request.
-func StartSpanOrTraceFromHTTPWithTraceParserHook(r *http.Request, parserHook TraceParserHook) (context.Context, *trace.Span) {
+func StartSpanOrTraceFromHTTPWithTraceParserHook(r *http.Request, parserHook config.HTTPTraceParserHook) (context.Context, *trace.Span) {
 	ctx := r.Context()
 	span := trace.GetSpanFromContext(ctx)
 	if span == nil {

--- a/wrappers/config/config.go
+++ b/wrappers/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"net/http"
+	"github.com/honeycombio/beeline-go/propagation"
+)
+
+// HTTPTraceParserHook is a function that will be invoked on all incoming HTTP requests
+// when it is passed as a parameter to an http.Handler wrapper function such as the
+// one provided in the hnynethttp package. It can be used to create a PropagationContext
+// object using trace context propagation headers in the provided http.Request. It is
+// expected that this hook will use one of the unmarshal functions exported in the
+// propagation package for a number of supported formats (e.g. Honeycomb, AWS,
+// W3C Trace Context, etc).
+type HTTPTraceParserHook func(*http.Request) *propagation.PropagationContext
+
+// HTTPTracePropagationHook is a function that will be invoked on all outgoing HTTP requests
+// when it is passed as a parameter to a RoundTripper wrapper function such as the one
+// provided in the hnynethttp package. It can be used to create a map of header names
+// to header values that will be injected in the outgoing request. The information in
+// the provided http.Request can be used to make decisions about what headers to include
+// in the outgoing request, for example based on the hostname of the target of the request.
+// The information in the provided PropagationContext should be used to create the serialized
+// header values. It is expected that this hook will use one of the marshal functions exported
+// in the propagation package for a number of supported formats (e.g. Honeycomb, AWS,
+// W3C Trace Context, etc).
+type HTTPTracePropagationHook func(*http.Request, *propagation.PropagationContext) map[string]string
+
+// WraperConfig stores configuration options used by various wrappers.
+type WrapperConfig struct {
+	HTTPParserHook      HTTPTraceParserHook
+	HTTPPropagationHook HTTPTracePropagationHook
+}

--- a/wrappers/config/config.go
+++ b/wrappers/config/config.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"net/http"
 	"github.com/honeycombio/beeline-go/propagation"
+	"net/http"
 )
 
 // HTTPTraceParserHook is a function that will be invoked on all incoming HTTP requests
@@ -26,8 +26,14 @@ type HTTPTraceParserHook func(*http.Request) *propagation.PropagationContext
 // W3C Trace Context, etc).
 type HTTPTracePropagationHook func(*http.Request, *propagation.PropagationContext) map[string]string
 
-// WraperConfig stores configuration options used by various wrappers.
-type WrapperConfig struct {
-	HTTPParserHook      HTTPTraceParserHook
+// HTTPIncomingConfig stores configuration options relevant to HTTP requests that are handled by
+// a wrapper.
+type HTTPIncomingConfig struct {
+	HTTPParserHook HTTPTraceParserHook
+}
+
+// HTTPOutgoingConfig stores configuration options relevant to HTTP requests being sent by an
+// instrumented application.
+type HTTPOutgoingConfig struct {
 	HTTPPropagationHook HTTPTracePropagationHook
 }

--- a/wrappers/hnynethttp/nethttp.go
+++ b/wrappers/hnynethttp/nethttp.go
@@ -173,6 +173,7 @@ func (ht *hnyTripper) spanRoundTrip(ctx context.Context, span *trace.Span, r *ht
 	}
 	span.AddField("meta.type", "http_client")
 	span.AddField("name", "http_client")
+	// If no propagation hook is defined, default to using the Honeycomb header format.
 	if ht.propagationHook == nil {
 		r.Header.Add(propagation.TracePropagationHTTPHeader, span.SerializeHeaders())
 	} else {

--- a/wrappers/hnynethttp/nethttp.go
+++ b/wrappers/hnynethttp/nethttp.go
@@ -19,7 +19,7 @@ import (
 // ServeMux instead, pull what you can from there. The provided config has a
 // HTTPTraceParserHook, it will be invoked when creating a new span or trace for
 // each incoming HTTP request.
-func WrapHandlerWithConfig(handler http.Handler, cfg config.WrapperConfig) http.Handler {
+func WrapHandlerWithConfig(handler http.Handler, cfg config.HTTPIncomingConfig) http.Handler {
 	// if we can cache handlerName here, let's do so for efficiency's sake
 	handlerName := runtime.FuncForPC(reflect.ValueOf(handler).Pointer()).Name()
 
@@ -82,7 +82,7 @@ func WrapHandlerWithConfig(handler http.Handler, cfg config.WrapperConfig) http.
 // all the standard HTTP fields attached. If passed a ServeMux instead, pull
 // what you can from there
 func WrapHandler(handler http.Handler) http.Handler {
-	return WrapHandlerWithConfig(handler, config.WrapperConfig{})
+	return WrapHandlerWithConfig(handler, config.HTTPIncomingConfig{})
 }
 
 // WrapHandlerFunc will create a Honeycomb event per invocation of this handler
@@ -218,7 +218,7 @@ func WrapRoundTripper(r http.RoundTripper) http.RoundTripper {
 // If the config contains a HTTPTracePropagationHook, it will be invoked on each outgoing
 // HTTP call. The return value, a map of header names to header strings, will be added
 // to the headers of the outgoing request.
-func WrapRoundTripperWithConfig(r http.RoundTripper, cfg config.WrapperConfig) http.RoundTripper {
+func WrapRoundTripperWithConfig(r http.RoundTripper, cfg config.HTTPOutgoingConfig) http.RoundTripper {
 	tripper := &hnyTripper{wrt: r}
 	if cfg.HTTPPropagationHook != nil {
 		tripper.propagationHook = cfg.HTTPPropagationHook

--- a/wrappers/hnynethttp/nethttp.go
+++ b/wrappers/hnynethttp/nethttp.go
@@ -84,7 +84,6 @@ func WrapHandler(handler http.Handler) http.Handler {
 	return WrapHandlerWithTraceParserHook(handler, nil)
 }
 
-
 // WrapHandlerFunc will create a Honeycomb event per invocation of this handler
 // function with all the standard HTTP fields attached.
 func WrapHandlerFunc(hf func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
@@ -122,7 +121,7 @@ func WrapHandlerFunc(hf func(http.ResponseWriter, *http.Request)) func(http.Resp
 
 type hnyTripper struct {
 	// wrt is the wrapped round tripper
-	wrt http.RoundTripper
+	wrt             http.RoundTripper
 	propagationHook common.TracePropagationHook
 }
 
@@ -220,7 +219,7 @@ func WrapRoundTripper(r http.RoundTripper) http.RoundTripper {
 // headers of the outgoing request.
 func WrapRoundTripperWithTracePropagationHook(r http.RoundTripper, propagationHook common.TracePropagationHook) http.RoundTripper {
 	return &hnyTripper{
-		wrt: r,
+		wrt:             r,
 		propagationHook: propagationHook,
 	}
 }


### PR DESCRIPTION
Allow users of the beeline to create custom hooks that define how
request headers can be mapped to propagation context on incoming HTTP
requests and how a propagation context can map to trace context headers
on outgoing HTTP requests.

The parser hook is used for incoming requests and is therefore passed to
the `WrapHandlerWithConfig` function in the `hnynethttp` package:

```
import (
    ....
    "github.com/honeycombio/beeline-go/wrappers/config"
)

// Parse incoming AWS headers (e.g. from a load balancer)
func traceParserHook(r *http.Request) *propagation.PropagationContext {
    header := r.Header.Get("X-Amzn-Trace-Id")
    prop, err := propagation.UnmarshalAmazonTraceContext(header)
    if err != nil {
        ...
    }
    return prop
}

log.Fatal(http.ListenAndServe(":8000", hnynethttp.WrapHandlerWithConfig(mux, config.HTTPIncomingConfig{
    HTTPParserHook: traceParserHook,
}))
```

The propagation hook is used on outgoing requests and is therefore passed to
the `WrapRoundTripperWithConfig` function in the `hnynethttp` package:

```
// Send W3C Trace Context headers on outgoing responses
func propagateTraceHeaders(r *http.Request, *propagation.PropagationContext) map[string]string {
    ctx := r.Context()
    ctx, headers := propagation.MarshalW3CTraceContext(ctx, prop)
    return headers
}

client := &http.Client{
    Transport: hnynethttp.WrapRoundTripperWithConfig(http.DefaultTransport, config.HTTPOutgoingConfig({
        HTTPPropagationHook: propagateTraceHeaders,
    }))
}
```