### PR TITLE
Include Parent segment, not Self when sending AWS headers.

### DIFF
--- a/propagation/amazon.go
+++ b/propagation/amazon.go
@@ -22,7 +22,7 @@ func MarshalAmazonTraceContext(prop *PropagationContext) string {
 	// From https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html:
 	// "If the X-Amzn-Trace-Id header is present and has a Self field, the load balancer updates
 	// the value of the Self field."
-	h := fmt.Sprintf("Root=%s;Self=%s", prop.TraceID, prop.ParentID)
+	h := fmt.Sprintf("Root=%s;Parent=%s", prop.TraceID, prop.ParentID)
 
 	if len(prop.TraceContext) != 0 {
 		elems := make([]string, len(prop.TraceContext))

--- a/propagation/amazon.go
+++ b/propagation/amazon.go
@@ -65,6 +65,7 @@ func UnmarshalAmazonTraceContext(header string) (*PropagationContext, error) {
 	// and root as the trace id.
 	prop := &PropagationContext{}
 	prop.TraceContext = make(map[string]interface{})
+	var parent string
 	for _, segment := range segments {
 		keyval := strings.SplitN(segment, "=", 2)
 		if len(keyval) < 2 {
@@ -75,9 +76,17 @@ func UnmarshalAmazonTraceContext(header string) (*PropagationContext, error) {
 			prop.ParentID = keyval[1]
 		case "root":
 			prop.TraceID = keyval[1]
+		case "parent":
+			parent = keyval[1]
 		default:
 			prop.TraceContext[keyval[0]] = keyval[1]
 		}
+	}
+
+	// Our primary use case is to support load balancers, so favor self over parent.
+	// If, however, a parent is present and self is not, use it.
+	if prop.ParentID == "" && parent != "" {
+		prop.ParentID = parent
 	}
 
 	// If no header is provided to an ALB or ELB, it will generate a header

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -118,7 +118,7 @@ func TestMarshalAmazonTraceContext(t *testing.T) {
 	header := MarshalAmazonTraceContext(prop)
 	// Note: we don't test trace context because we can't gaurantee the order.
 	// It's covered by the roundtrip test below.
-	assert.Equal(t, "Root=abcdef123456;Self=0102030405", header[0:33])
+	assert.Equal(t, "Root=abcdef123456;Parent=0102030405", header[0:35])
 
 	returned, err := UnmarshalAmazonTraceContext(header)
 	if assert.NoError(t, err) {
@@ -292,26 +292,12 @@ func TestUnmarshalAmazonTraceContext(t *testing.T) {
 			false,
 		},
 		{
-			"self, parent and root fields. parent should end up in trace context",
-			"Root=foo;Parent=bar;Self=baz",
-			&PropagationContext{
-				TraceID:  "foo",
-				ParentID: "baz",
-				TraceContext: map[string]interface{}{
-					"Parent": "bar",
-				},
-			},
-			false,
-		},
-		{
-			"self, parent and root fields. parent should end up in trace context",
+			"self, parent and root fields. parent should end up dropped",
 			"Root=foo;Self=baz;Parent=bar",
 			&PropagationContext{
 				TraceID:  "foo",
 				ParentID: "baz",
-				TraceContext: map[string]interface{}{
-					"Parent": "bar",
-				},
+				TraceContext: map[string]interface{}{},
 			},
 			false,
 		},


### PR DESCRIPTION
AWS headers are propagated when a service call is expected to cross an
ALB or ELB in between service boundaries. Amazon load balancers will
respect the value sent in the Parent segment of the X-Amzn-Trace-Id
header and log the value as the parent of the request.

Additionally, modify the parsing logic so that if Parent and Self are both
present in an Amazon header, respect Self since it comes from the load
balancer. If Parent is present and Self is not, use Parent. If neither are
present, but Root is, use it as the trace and parent ID.