### PR TITLE
Disable validation check on Unmarshal for Honeycomb headers

### DIFF
--- a/propagation/honeycomb.go
+++ b/propagation/honeycomb.go
@@ -96,8 +96,8 @@ func unmarshalHoneycombTraceContextV1(header string) (*PropagationContext, error
 			tcB64 = keyval[1]
 		}
 	}
-	if !prop.IsValid() {
-		return nil, &PropagationError{fmt.Sprintf("Could not create propagation context from header: %s", header), nil}
+	if prop.TraceID == "" && prop.ParentID != "" {
+		return nil, &PropagationError{"parent_id without trace_id", nil}
 	}
 	if tcB64 != "" {
 		data, err := base64.StdEncoding.DecodeString(tcB64)

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -93,9 +93,6 @@ func TestMarshalTraceContext(t *testing.T) {
 	marshaled = MarshalTraceContext(prop)
 	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
 	assert.Equal(t, "1;trace_id=,parent_id=,dataset=imadataset,context=bnVsbA==", marshaled)
-
-	returned, err = UnmarshalTraceContext(marshaled)
-	assert.Error(t, err, "should not be able to unmarshal header without trace_id or parent_id")
 }
 
 func TestMarshalAmazonTraceContext(t *testing.T) {
@@ -203,12 +200,6 @@ func TestUnmarshalTraceContext(t *testing.T) {
 		{
 			"v1, parent_id without trace_id",
 			"1;parent_id=12345",
-			nil,
-			true,
-		},
-		{
-			"v1, missing parent_id, should return an error",
-			"1;trace_id=12345",
 			nil,
 			true,
 		},


### PR DESCRIPTION
The `IsValid()` function on `propagation.PropagationContext` is intended to
validate `PropagationContext` objects that are either created from
incoming trace context headers, or used to generate outgoing trace
context headers. In either case, the context had better contain a
`ParentID` or it is not valid.

There is a use case, however, with Honeycomb headers, where a user of
older beeline versions would create a `PropagationContext` (aliased as
`Propagation`) manually, and then serialize it as a Honeycomb header to
create a new `trace.Trace`. In this case, the `PropagationContext` would not
necessarily have a `TraceID` or a `ParentId`, and so it would fail `IsValid`.