### PR TITLE
Protect against potential data race in working with propagation context

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -132,15 +132,25 @@ func (t *Trace) AddField(key string, val interface{}) {
 // The serialized form may be passed to NewTrace() in order to create a new
 // trace that will be connected to this trace.
 func (t *Trace) serializeHeaders(spanID string) string {
-	var prop = &propagation.PropagationContext{
-		TraceID:      t.traceID,
-		ParentID:     spanID,
-		Dataset:      t.builder.Dataset,
-		TraceContext: t.traceLevelFields,
-	}
-	t.tlfLock.RLock()
-	defer t.tlfLock.RUnlock()
+	prop := t.propagationContext()
+	prop.ParentID = spanID
 	return propagation.MarshalTraceContext(prop)
+}
+
+func (t *Trace) propagationContext() *propagation.PropagationContext {
+	// make a copy of the trace level fields map since we can't lock our
+	// returned value to protect it
+	t.tlfLock.Lock()
+	defer t.tlfLock.Unlock()
+	localTLF := map[string]interface{}{}
+	for k, v := range t.traceLevelFields {
+		localTLF[k] = v
+	}
+	return &propagation.PropagationContext{
+		TraceID:      t.traceID,
+		Dataset:      t.builder.Dataset,
+		TraceContext: localTLF,
+	}
 }
 
 // addRollupField is here to let a span contribute a field to the trace while
@@ -508,10 +518,7 @@ func (s *Span) createChildSpan(ctx context.Context, async bool) (context.Context
 // PropagationContext creates and returns a new propagation.PropagationContext using the
 // information in the current span.
 func (s *Span) PropagationContext() *propagation.PropagationContext {
-	return &propagation.PropagationContext{
-		TraceID:      s.trace.traceID,
-		ParentID:     s.spanID,
-		Dataset:      s.trace.builder.Dataset,
-		TraceContext: s.trace.traceLevelFields,
-	}
+	prop := s.trace.propagationContext()
+	prop.ParentID = s.spanID
+	return prop
 }


### PR DESCRIPTION
There are two ways to get propagation headers out of the go beeline. The function to serialize headers (that returns the beeline header format) and the newer request for a `PropagationContext` object which can then be serialized into custom formats using the wrapper's propagation hooks. 

Unfortunately the latter form does not protect the trace level fields map from concurrent access. The effect is that if one gets a propagation context object and simultaneously adds a trace level field, a data race on that map access can occur. 

The first commit in this PR adds a test that confirms this race can happen. Switching your git checkout to f22a86c and running `go test ./... -race` will spit out the dreaded `WARNING: DATA RACE` message. Moving back to past the second commit in this PR and re-running the tests will show that moving the portion that works on the trace level fields into the `Trace`-attached method and making a copy of the fields protects against that race. 

The interface for calling either of these methods is unchanged. 