### PR TITLE
Update example honeycomb header

### DIFF
--- a/propagation/honeycomb.go
+++ b/propagation/honeycomb.go
@@ -22,7 +22,7 @@ import (
 //  dataset=${datasetId}   - datasetId is the slug for the honeycomb dataset to which downstream spans should be sent; shall not include ','
 //  context=${contextBlob} - contextBlob is a base64 encoded json object.
 //
-// ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
+// ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=eyJoZWxsbyI6IndvcmxkIn0=
 
 const (
 	TracePropagationHTTPHeader = "X-Honeycomb-Trace"


### PR DESCRIPTION
The example header in the honeycomb propagator has an invalid context value. The context should be a base64 encoded json object that is translated into a map as trace fields. However, the current example is a simple encoded string.

Current base64 value: `Hello World`
Updated base64 value: `{"hello":"world"}`

Closes #147.