### PR TITLE
Use separate CircleCI context for public repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ workflows:
               tags:
                 only: /.*/
       - publish_github:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           filters:
               tags:
                 only: /^v.*/


### PR DESCRIPTION
In order to have CirlceCI push draft releases to github there is a separate API token that allows pushing artifacts. We set up a separate CircleCI context that has an API token with that right. Trying it out to see if it works!