### PR TITLE
Adding a gRPC interceptor wrapper.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.opentelemetry.io/contrib/propagators v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	goji.io/v3 v3.0.0
+	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/propagation/honeycomb.go
+++ b/propagation/honeycomb.go
@@ -25,6 +25,7 @@ import (
 // ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=eyJoZWxsbyI6IndvcmxkIn0=
 
 const (
+	TracePropagationGRPCHeader = "x-honeycomb-trace" // difference in case matters here
 	TracePropagationHTTPHeader = "X-Honeycomb-Trace"
 	TracePropagationVersion    = 1
 )

--- a/wrappers/config/config.go
+++ b/wrappers/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"github.com/honeycombio/beeline-go/propagation"
 	"net/http"
 )
@@ -36,4 +37,17 @@ type HTTPIncomingConfig struct {
 // instrumented application.
 type HTTPOutgoingConfig struct {
 	HTTPPropagationHook HTTPTracePropagationHook
+}
+
+// GRPCTraceParserHook is a function that will be invoked on all incoming gRPC requests
+// when it is passed as a parameter to an interceptor wrapper function such as the one
+// provided in the hnygrpc package. It can be used to create a PropagationContext object
+// using trace context propagation headers in the provided context. It is functionally
+// identical to its HTTP counterpart, HTTPTraceParserHook.
+type GRPCTraceParserHook func(context.Context) *propagation.PropagationContext
+
+// GRPCIncomingConfig stores configuration options relevant to gRPC requests that are
+// handled by a wrapped gRPC interceptor provided in the hnygrpc package.
+type GRPCIncomingConfig struct {
+	GRPCParserHook GRPCTraceParserHook
 }

--- a/wrappers/hnygrpc/doc.go
+++ b/wrappers/hnygrpc/doc.go
@@ -1,0 +1,21 @@
+// Package hnygrpc provides wrappers and other utilities for autoinstrumenting
+// gRPC services.
+//
+// Usage
+//
+// The Honeycomb beeline takes advantage of gRPC interceptors to instrument
+// RPCs. The wrapped interceptor can take a `config.GRPCIncomingConfig` object
+// which can optionally provide a custom trace parser hook, allowing for easy
+// interoperability between W3C, B3, Honeycomb and other trace header formats.
+//
+//     serverOpts := []grpc.ServerOption{
+//         grpc.UnaryInterceptor(hnygrpc.UnaryServerInterceptorWithConfig(cfg)),
+//     }
+//     server := grpc.NewServer(serverOpts...)
+//
+// Requests received by the server will now generate Honeycomb events, with
+// metadata related to the request included as fields.
+//
+// Please note that only unary RPCs are supported at this time. Support for
+// streaming RPCs may be added later.
+package hnygrpc

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -1,0 +1,111 @@
+package hnygrpc
+
+import (
+	"context"
+	"reflect"
+	"runtime"
+
+	"github.com/honeycombio/beeline-go/propagation"
+	"github.com/honeycombio/beeline-go/trace"
+	"github.com/honeycombio/beeline-go/wrappers/config"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// getMetadataStringValue is a simpler helper method that checks the provided
+// metadata for a value associated with the provided key. If the value exists,
+// it is returned. If the value does not exist, an empty string is returned.
+func getMetadataStringValue(md metadata.MD, key string) string {
+	if val, ok := md[key]; ok {
+		if len(val) > 0 {
+			return val[0]
+		}
+		return ""
+	}
+	return ""
+}
+
+// startSpanOrTraceFromUnaryGRPC checks to see if a trace already exists in the
+// provided context before creating either a root span or a child span of the
+// existing active span. The function understands trace parser hooks, so if one
+// is provided, it'll use it to parse the incoming request for trace context.
+func startSpanOrTraceFromUnaryGRPC(
+	ctx context.Context,
+	info *grpc.UnaryServerInfo,
+	parserHook config.GRPCTraceParserHook,
+) (context.Context, *trace.Span) {
+	span := trace.GetSpanFromContext(ctx)
+	if span == nil {
+		// no active span, create a new trace
+		var tr *trace.Trace
+		md, ok := metadata.FromIncomingContext(ctx)
+		if ok {
+			if parserHook == nil {
+				beelineHeader := getMetadataStringValue(md, propagation.TracePropagationHTTPHeader)
+				ctx, tr = trace.NewTrace(ctx, beelineHeader)
+			} else {
+				prop := parserHook(ctx)
+				ctx, tr = trace.NewTraceFromPropagationContext(ctx, prop)
+			}
+		} else {
+			ctx, tr = trace.NewTrace(ctx, "")
+		}
+		span = tr.GetRootSpan()
+	} else {
+		// create new span as child of active span.
+		ctx, span = span.CreateChild(ctx)
+	}
+	return ctx, span
+}
+
+// addFields just adds available information about a gRPC request to the provided span.
+func addFields(ctx context.Context, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, span *trace.Span) {
+	handlerName := runtime.FuncForPC(reflect.ValueOf(handler).Pointer()).Name()
+
+	span.AddField("handler.name", handlerName)
+	span.AddField("name", handlerName)
+	span.AddField("handler.method", info.FullMethod)
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if val, ok := md["content-type"]; ok {
+			span.AddField("request.content_type", val[0])
+		}
+		if val, ok := md[":authority"]; ok {
+			span.AddField("request.header.authority", val[0])
+		}
+		if val, ok := md["user-agent"]; ok {
+			span.AddField("request.header.user_agent", val[0])
+		}
+	}
+}
+
+// UnaryServerInterceptorWithConfig will create a Honeycomb event per invocation of the
+// returned interceptor. If passed a config.GRPCIncomingConfig with a GRPCParserHook,
+// the hook will be called when creating the event, allowing it to specify how trace context
+// information should be included in the span (e.g. it may have come from a remote parent in
+// a specific format).
+//
+// Events created from GRPC interceptors will contain information from the gRPC metadata, if
+// it exists, as well as information about the handler used and method being called.
+func UnaryServerInterceptorWithConfig(cfg config.GRPCIncomingConfig) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		ctx, span := startSpanOrTraceFromUnaryGRPC(ctx, info, cfg.GRPCParserHook)
+		defer span.Send()
+
+		addFields(ctx, info, handler, span)
+		resp, err := handler(ctx, req)
+		if err != nil {
+			span.AddTraceField("handler_error", err.Error())
+		}
+		span.AddField("response.grpc_status_code", status.Code(err))
+		return resp, err
+	}
+}

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -43,7 +43,7 @@ func startSpanOrTraceFromUnaryGRPC(
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok {
 			if parserHook == nil {
-				beelineHeader := getMetadataStringValue(md, propagation.TracePropagationHTTPHeader)
+				beelineHeader := getMetadataStringValue(md, propagation.TracePropagationGRPCHeader)
 				ctx, tr = trace.NewTrace(ctx, beelineHeader)
 			} else {
 				prop := parserHook(ctx)

--- a/wrappers/hnygrpc/grpc_test.go
+++ b/wrappers/hnygrpc/grpc_test.go
@@ -1,0 +1,69 @@
+package hnygrpc
+
+import (
+	"context"
+	"testing"
+
+	beeline "github.com/honeycombio/beeline-go"
+	"github.com/honeycombio/beeline-go/wrappers/config"
+	libhoney "github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
+	"github.com/stretchr/testify/assert"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestUnaryInterceptor(t *testing.T) {
+	mo := &transmission.MockSender{}
+	client, err := libhoney.NewClient(libhoney.ClientConfig{
+		APIKey:       "placeholder",
+		Dataset:      "placeholder",
+		APIHost:      "placeholder",
+		Transmission: mo})
+	assert.Equal(t, nil, err)
+	beeline.Init(beeline.Config{Client: client})
+
+	md := metadata.New(map[string]string{
+		"content-type": "application/grpc",
+		":authority":   "api.honeycomb.io:443",
+		"user-agent":   "testing-is-fun",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return req, nil
+	}
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "test.method",
+	}
+	interceptor := UnaryServerInterceptorWithConfig(config.GRPCIncomingConfig{})
+	var dummy interface{}
+	resp, err := interceptor(ctx, dummy, info, handler)
+	assert.NoError(t, err, "Unexpected error calling interceptor")
+	assert.Equal(t, resp, dummy)
+
+	evs := mo.Events()
+	assert.Equal(t, 1, len(evs), "1 event is created")
+	successfulFields := evs[0].Data
+
+	contentType, ok := successfulFields["request.content_type"]
+	assert.True(t, ok, "content-type field must exist on middleware generated event")
+	assert.Equal(t, "application/grpc", contentType, "content-type should be set")
+
+	authority, ok := successfulFields["request.header.authority"]
+	assert.True(t, ok, "authority field must exist on middleware generated event")
+	assert.Equal(t, "api.honeycomb.io:443", authority, "authority should be set")
+
+	userAgent, ok := successfulFields["request.header.user_agent"]
+	assert.True(t, ok, "user-agent expected to exist on middleware generated event")
+	assert.Equal(t, "testing-is-fun", userAgent, "user-agent should be set")
+
+	method, ok := successfulFields["handler.method"]
+	assert.True(t, ok, "method name should be set")
+	assert.Equal(t, "test.method", method, "method name should be set")
+
+	status, ok := successfulFields["response.grpc_status_code"]
+	assert.True(t, ok, "Status code must exist on middleware generated event")
+	assert.Equal(t, codes.OK, status, "status must exist")
+}


### PR DESCRIPTION
This allows users to instrument gRPC services by providing a wrapped interceptor when creating a server:

```
serverOpts := []grpc.ServerOption{
	grpc.UnaryInterceptor(hnygrpc.UnaryServerInterceptorWithConfig(...)),
}
server := grpc.NewServer(serverOpts...)
```

Note that at the moment, only unary RPCs are supported. Streaming gRPC clients and servers can be added later. Outgoing instrumentation is also not supported yet, hence no `config.GRPCOutgoingConfig` or propagation hook included in this PR.