### PR TITLE
Ensure rollup fields are included on subroot spans

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -470,7 +470,7 @@ func (s *Span) send() {
 	s.childrenLock.Unlock()
 	s.AddField("meta.span_type", spanType)
 
-	if spanType == "root" {
+	if s.isRoot {
 		// add the trace's rollup fields to the root span
 		for k, v := range s.trace.getRollupFields() {
 			s.AddField("rollup."+k, v)


### PR DESCRIPTION
The current implementation of rollup fields will only add them to spans
that are marked as `root` spans. Spans are only labelled as "root" when
they created the trace, and have no parent. Spans that are created from
a trace's propagation context are instead marked as `subroot`.

Unfortunately this means that other apps participating in the trace are
unable to utilize rollup fields, as the root of their in-process trace
will never be `root`.

This commit tweaks the trace's `Send()` function to allow rollup fields
to be added to `subroot` spans.

Ben mentioned that the `meta.span_type` field may be deprecated at some
point (and presumably `spanType` along with it), so it seemed better to
rely on the span's internal `isRoot` boolean for deciding on whether
rollup fields should be added.

https://honeycombpollinators.slack.com/archives/CLXQWT35J/p1592847384010900