### PR TITLE
Default w3c sampled flag to 01

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"go.opentelemetry.io/otel/trace"
 	"sync"
 	"time"
 
@@ -154,6 +155,7 @@ func (t *Trace) propagationContext() *propagation.PropagationContext {
 		TraceID:      t.traceID,
 		Dataset:      t.builder.Dataset,
 		TraceContext: localTLF,
+		TraceFlags:   trace.FlagsSampled, // TODO: set the sampled flag based on sampler decision
 	}
 }
 


### PR DESCRIPTION
Receiving OTEL instrumentation ignores spans coming with the 00 sampled flag.

This is a stop-gap measure to ensure w3c parser hooks work with an OTEL receiver. Ideally, we would like to set the sampled flag based on an actual sampler, but that requires further investigation.

### Considerations
We can't default the `TraceFlags` in the actual `w3c.MarshalW3CTraceContext` because by then we can't differentiate the zero-value `PropagationContext.TraceFlags` from an actual `00` flag. Making `TraceFlags` a pointer (or something similar) would break the public interface.

Since `PropagationContext.TraceFlags` is currently only consumed by `w3c.MarshalW3CTraceContext`, it seemed _OK_ to do it here.