### PR TITLE
Set additional response header values in hnygorilla wrapper

### DIFF
--- a/wrappers/hnygorilla/gorilla.go
+++ b/wrappers/hnygorilla/gorilla.go
@@ -58,6 +58,15 @@ func Middleware(handler http.Handler) http.Handler {
 		if wrappedWriter.Status == 0 {
 			wrappedWriter.Status = 200
 		}
+		if cl := wrappedWriter.Wrapped.Header().Get("Content-Length"); cl != "" {
+			span.AddField("response.content_length", cl)
+		}
+		if ct := wrappedWriter.Wrapped.Header().Get("Content-Type"); ct != "" {
+			span.AddField("response.content_type", ct)
+		}
+		if ce := wrappedWriter.Wrapped.Header().Get("Content-Encoding"); ce != "" {
+			span.AddField("response.content_encoding", ce)
+		}
 		span.AddField("response.status_code", wrappedWriter.Status)
 	}
 	return http.HandlerFunc(wrappedHandler)


### PR DESCRIPTION
Fixes #164.

The hnynethttp wrapper adds fields for response headers other than the status code, and the same would be useful in the hnygorilla wrapper:
https://github.com/honeycombio/beeline-go/blob/5f09432b6f3de0e6107f87d25a134b95bd94850a/wrappers/hnynethttp/nethttp.go#L67-L75