### PR TITLE
Remove deprecated wrappers in prep for major release

### DIFF
--- a/beeline.go
+++ b/beeline.go
@@ -262,7 +262,7 @@ func StartSpan(ctx context.Context, name string) (context.Context, *trace.Span) 
 		// there is no trace active; we should make one, but use the root span
 		// as the "new" span instead of creating a child of this mostly empty
 		// span
-		ctx, _ = trace.NewTrace(ctx, "")
+		ctx, _ = trace.NewTrace(ctx, nil)
 		newSpan = trace.GetSpanFromContext(ctx)
 	}
 	newSpan.AddField("name", name)

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -37,11 +37,6 @@ func (prop PropagationContext) IsValid() bool {
 	return prop.hasTraceID() && prop.hasParentID()
 }
 
-// Propagation contains information about a trace.
-//
-// Deprecated: use PropagationContext instead.
-type Propagation = PropagationContext
-
 // PropagationError wraps any error encountered while parsing or serializing trace propagation
 // contexts.
 type PropagationError struct {
@@ -55,25 +50,4 @@ func (p *PropagationError) Error() string {
 		return p.message
 	}
 	return fmt.Sprintf(p.message, p.wrappedError)
-}
-
-// MarshalTraceContext wraps MarshalHoneycombTraceContext for backwards compatibility.
-//
-// Deprecated: Use MarshalHoneycombTraceContext.
-func MarshalTraceContext(prop *PropagationContext) string {
-	return MarshalHoneycombTraceContext(prop)
-}
-
-// UnmarshalTraceContext wraps UnmarshalHoneycombTraceContext for backwards compatibility.
-//
-// Deprecated: Use UnmarshalHoneycombTraceContext
-func UnmarshalTraceContext(header string) (*PropagationContext, error) {
-	return UnmarshalHoneycombTraceContext(header)
-}
-
-// UnmarshalTraceContextV1 wraps UnmarshalHoneycombTraceContextV1 for backwards compatibility.
-//
-// Deprecated: Use UnmarshalHoneycombTraceContext. Do not call this function directly.
-func UnmarshalTraceContextV1(header string) (*PropagationContext, error) {
-	return unmarshalHoneycombTraceContextV1(header)
 }

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -156,7 +156,7 @@ func TestMarshalHoneycombTraceContext(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		marshaled := MarshalTraceContext(tt.prop)
+		marshaled := MarshalHoneycombTraceContext(tt.prop)
 		assert.Equal(t, tt.marshaledProp, marshaled, tt.name)
 	}
 
@@ -175,36 +175,36 @@ func TestRoundTripHoneycombTraceContext(t *testing.T) {
 		},
 	}
 
-	marshaled := MarshalTraceContext(prop)
+	marshaled := MarshalHoneycombTraceContext(prop)
 	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
 	assert.Equal(t, "1;trace_id=abcdef123456,parent_id=0102030405,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==", marshaled)
 
-	returned, err := UnmarshalTraceContext(marshaled)
+	returned, err := UnmarshalHoneycombTraceContext(marshaled)
 	assert.Equal(t, prop, returned, "roundtrip object")
 	assert.NoError(t, err, "roundtrip error")
 
 	prop.Dataset = "imadataset"
-	marshaled = MarshalTraceContext(prop)
+	marshaled = MarshalHoneycombTraceContext(prop)
 	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
 	assert.Equal(t, "1;trace_id=abcdef123456,parent_id=0102030405,dataset=imadataset,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==", marshaled)
 
-	returned, err = UnmarshalTraceContext(marshaled)
+	returned, err = UnmarshalHoneycombTraceContext(marshaled)
 	assert.Equal(t, prop, returned, "roundtrip object")
 	assert.NoError(t, err, "roundtrip error")
 
 	prop.Dataset = "ill;egal"
-	marshaled = MarshalTraceContext(prop)
+	marshaled = MarshalHoneycombTraceContext(prop)
 	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
 	assert.Equal(t, "1;trace_id=abcdef123456,parent_id=0102030405,dataset=ill%3Begal,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ==", marshaled)
 
-	returned, err = UnmarshalTraceContext(marshaled)
+	returned, err = UnmarshalHoneycombTraceContext(marshaled)
 	assert.Equal(t, prop, returned, "roundtrip object")
 	assert.NoError(t, err, "roundtrip error")
 
 	prop = &PropagationContext{
 		Dataset: "imadataset",
 	}
-	marshaled = MarshalTraceContext(prop)
+	marshaled = MarshalHoneycombTraceContext(prop)
 	assert.Equal(t, "1;", marshaled[0:2], "version of marshaled context should be 1")
 	assert.Equal(t, "1;trace_id=,parent_id=,dataset=imadataset,context=bnVsbA==", marshaled)
 }
@@ -324,7 +324,7 @@ func TestB3TraceContext(t *testing.T) {
 	assert.Error(t, err, "Cannot unmarshal empty header")
 }
 
-func TestUnmarshalTraceContext(t *testing.T) {
+func TestUnmarshalHoneycombTraceContext(t *testing.T) {
 	testCases := []struct {
 		name       string
 		contextStr string
@@ -404,7 +404,7 @@ func TestUnmarshalTraceContext(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		prop, err := UnmarshalTraceContext(tt.contextStr)
+		prop, err := UnmarshalHoneycombTraceContext(tt.contextStr)
 		assert.Equal(t, tt.prop, prop, tt.name)
 		if tt.returnsErr {
 			assert.Error(t, err, tt.name)

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTraceFromContext(t *testing.T) {
-	ctx, tr := NewTrace(context.Background(), "")
+	ctx, tr := NewTrace(context.Background(), nil)
 	trInCtx := GetTraceFromContext(ctx)
 	assert.Equal(t, tr, trInCtx, "trace from context should be the trace we got from making a new trace")
 	emptyTrace := &Trace{}
@@ -18,7 +18,7 @@ func TestTraceFromContext(t *testing.T) {
 }
 
 func TestSpanFromContext(t *testing.T) {
-	ctx, tr := NewTrace(context.Background(), "")
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 	spanInCtx := GetSpanFromContext(ctx)
 	assert.Equal(t, rs, spanInCtx, "span from context should be the root span we got from making a new trace")
@@ -29,7 +29,7 @@ func TestSpanFromContext(t *testing.T) {
 }
 
 func TestCopyContext(t *testing.T) {
-	ctx, tr := NewTrace(context.Background(), "")
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 
 	newCtx, err := CopyContext(context.Background(), ctx)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -57,6 +57,8 @@ func getNewID(length uint16) string {
 
 // NewTraceFromPropagationContext creates a brand new trace. prop is optional, and if included,
 // should be populated with data from a trace context header.
+//
+// Deprecated: use NewTrace instead.
 func NewTraceFromPropagationContext(ctx context.Context, prop *propagation.PropagationContext) (context.Context, *Trace) {
 	trace := &Trace{
 		builder:          client.NewBuilder(),
@@ -98,7 +100,7 @@ func NewTraceFromPropagationContext(ctx context.Context, prop *propagation.Propa
 // included, should be the header as written by trace.SerializeHeaders(). When
 // not starting from an upstream trace, pass the empty string here.
 //
-// Deprecated: users should call NewTraceFromPropagationContext instead.
+// Deprecated: use NewTrace instead.
 func NewTraceFromSerializedHeaders(ctx context.Context, serializedHeaders string) (context.Context, *Trace) {
 	var prop *propagation.PropagationContext
 	if serializedHeaders != "" {
@@ -107,11 +109,10 @@ func NewTraceFromSerializedHeaders(ctx context.Context, serializedHeaders string
 	return NewTraceFromPropagationContext(ctx, prop)
 }
 
-// NewTrace creates a new trace. This wraps NewTraceFromSerializedHeaders and may be changed in
-// a future release to wrap NewTraceFromPropagationContext instead. Users should start calling
-// that method to avoid backwards incompatibilities with the next major release.
-func NewTrace(ctx context.Context, serializedHeaders string) (context.Context, *Trace) {
-	return NewTraceFromSerializedHeaders(ctx, serializedHeaders)
+// NewTrace creates a new trace. prop is optional, and if included,
+// should be populated with data from a trace context header.
+func NewTrace(ctx context.Context, prop *propagation.PropagationContext) (context.Context, *Trace) {
+	return NewTraceFromPropagationContext(ctx, prop)
 }
 
 // AddField adds a field to the trace. Every span in the trace will have this
@@ -135,7 +136,7 @@ func (t *Trace) AddField(key string, val interface{}) {
 func (t *Trace) serializeHeaders(spanID string) string {
 	prop := t.propagationContext()
 	prop.ParentID = spanID
-	return propagation.MarshalTraceContext(prop)
+	return propagation.MarshalHoneycombTraceContext(prop)
 }
 
 // propagationContext returns a partially populated propagation context. It only

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestNewTrace create traces and make sure they're populated with all the
+// TestNewTraceFromSerializedHeaders create traces and make sure they're populated with all the
 // expected things
-func TestNewTrace(t *testing.T) {
+func TestNewTraceFromSerializedHeaders(t *testing.T) {
 	// test basic new trace
-	ctx, tr := NewTrace(context.Background(), "")
+	ctx, tr := NewTraceFromSerializedHeaders(context.Background(), "")
 	assert.NotNil(t, tr.builder, "traces should have a builder")
 	assert.NotEmpty(t, tr.traceID, "trace should have a trace ID")
 	assert.Empty(t, tr.parentID, "trace created with no headers should have an empty parent ID")
@@ -38,7 +38,7 @@ func TestNewTrace(t *testing.T) {
 	// three fields are {"userID":1,"errorMsg":"failed to sign on","toRetry":true}
 	// string taken from propagation_test.go
 	serializedHeaders := "1;trace_id=abcdef123456,parent_id=0102030405,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ=="
-	_, tr = NewTrace(context.Background(), serializedHeaders)
+	_, tr = NewTraceFromSerializedHeaders(context.Background(), serializedHeaders)
 	assert.Equal(t, "abcdef123456", tr.traceID, "trace with headers should take trace ID")
 	assert.Equal(t, "0102030405", tr.parentID, "trace with headers should take parent ID")
 	assert.Equal(t, float64(1), tr.traceLevelFields["userID"], "trace with headers should populate trace level fields")
@@ -60,10 +60,10 @@ func TestNewTrace(t *testing.T) {
 	})
 }
 
-// TestNewTraceFromPropagationContext creates traces using data in a struct and
+// TestNewTrace creates traces using data in a struct and
 // makes sure they're populated with all the things we want.
-func TestNewTraceFromPropagationContext(t *testing.T) {
-	ctx, tr := NewTraceFromPropagationContext(context.Background(), nil)
+func TestNewTrace(t *testing.T) {
+	ctx, tr := NewTrace(context.Background(), nil)
 	assert.NotNil(t, tr.builder, "traces should have a builder")
 	assert.NotEmpty(t, tr.traceID, "trace should have a trace ID")
 	assert.Empty(t, tr.parentID, "trace created with no propagation context should have an empty parent ID")
@@ -90,7 +90,7 @@ func TestNewTraceFromPropagationContext(t *testing.T) {
 			"toRetry":  true,
 		},
 	}
-	_, tr = NewTraceFromPropagationContext(ctx, prop)
+	_, tr = NewTrace(ctx, prop)
 	assert.Equal(t, "0af7651916cd43dd8448eb211c80319c", tr.traceID, "trace with a propagation context should take trace ID")
 	assert.Equal(t, "00f067aa0ba902b7", tr.parentID, "trace with a propagation context should take parent ID")
 	assert.Equal(t, int(1), tr.traceLevelFields["userID"], "trace with a propagation context should populate trace level fields")
@@ -100,14 +100,14 @@ func TestNewTraceFromPropagationContext(t *testing.T) {
 
 // TestAddField tests adding a field to a trace
 func TestAddField(t *testing.T) {
-	_, tr := NewTrace(context.Background(), "")
+	_, tr := NewTrace(context.Background(), nil)
 	tr.AddField("wander", "lust")
 	assert.Equal(t, "lust", tr.traceLevelFields["wander"], "AddField on a trace should add the field to the trace level fields map")
 }
 
 // TestRollupField tests adding a field to a trace
 func TestRollupField(t *testing.T) {
-	_, tr := NewTrace(context.Background(), "")
+	_, tr := NewTrace(context.Background(), nil)
 	tr.addRollupField("bignum", 5)
 	tr.addRollupField("bignum", 5)
 	tr.addRollupField("smallnum", 0.1)
@@ -119,7 +119,7 @@ func TestRollupFieldsPropagateToRoot(t *testing.T) {
 	t.Run("check rolling up to the root of a trace that was created in this process", func(t *testing.T) {
 		mo := setupLibhoney()
 
-		_, tr := NewTrace(context.Background(), "")
+		_, tr := NewTrace(context.Background(), nil)
 		tr.addRollupField("bignum", 5)
 		tr.Send()
 
@@ -130,9 +130,9 @@ func TestRollupFieldsPropagateToRoot(t *testing.T) {
 	})
 	t.Run("check rolling up to the root span of a trace that was propagated from a different system", func(t *testing.T) {
 		mo := setupLibhoney()
-		_, parentTr := NewTrace(context.Background(), "")
+		_, parentTr := NewTrace(context.Background(), nil)
 
-		_, tr := NewTrace(context.Background(), propagation.MarshalTraceContext(parentTr.GetRootSpan().PropagationContext()))
+		_, tr := NewTrace(context.Background(), parentTr.GetRootSpan().PropagationContext())
 		tr.addRollupField("bignum", 5)
 		tr.Send()
 
@@ -145,7 +145,7 @@ func TestRollupFieldsPropagateToRoot(t *testing.T) {
 
 // TestGetRootSpan verifies the real root span is returned
 func TestGetRootSpan(t *testing.T) {
-	_, tr := NewTrace(context.Background(), "")
+	_, tr := NewTrace(context.Background(), nil)
 	sp := tr.GetRootSpan()
 	assert.Equal(t, tr.rootSpan, sp, "get root span should return the trace's root span")
 }
@@ -154,7 +154,7 @@ func TestGetRootSpan(t *testing.T) {
 // synchronous children
 func TestSendTrace(t *testing.T) {
 	mo := setupLibhoney()
-	ctx, tr := NewTrace(context.Background(), "")
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 	rs.AddField("name", "rs")
 	ctx, c1 := rs.CreateChild(ctx)
@@ -203,7 +203,7 @@ func TestSendTrace(t *testing.T) {
 func TestSpan(t *testing.T) {
 	mo := setupLibhoney()
 
-	ctx, tr := NewTrace(context.Background(), "")
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 
 	ctx, span := rs.CreateChild(ctx)
@@ -318,7 +318,7 @@ func TestSpan(t *testing.T) {
 
 func TestCreateAsyncSpanDoesNotCauseRaceInSend(t *testing.T) {
 	setupLibhoney()
-	ctx, tr := NewTrace(context.Background(), t.Name())
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 
 	wg := &sync.WaitGroup{}
@@ -340,7 +340,7 @@ func TestCreateAsyncSpanDoesNotCauseRaceInSend(t *testing.T) {
 // on the number of chilrden in a span.
 func TestCreateSubSpanDoesNotCauseRaceInSend(t *testing.T) {
 	setupLibhoney()
-	ctx, tr := NewTrace(context.Background(), t.Name())
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 	ctx, subsp := rs.CreateChild(ctx)
 
@@ -363,7 +363,7 @@ func TestChildAndParentSendsDoNotRace(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(10)
 	for i := 0; i < 5; i++ {
-		ctx, tr := NewTrace(context.Background(), t.Name())
+		ctx, tr := NewTrace(context.Background(), nil)
 		rs := tr.GetRootSpan()
 
 		go func() {
@@ -412,7 +412,7 @@ func TestAddFieldDoesNotCauseRaceInSendHooks(t *testing.T) {
 		wg.Done()
 	}()
 
-	ctx, tr := NewTrace(context.Background(), "")
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 
 	for i := 0; i < 100; i++ {
@@ -440,8 +440,7 @@ func TestPropagatedFields(t *testing.T) {
 			"toRetry":  true,
 		},
 	}
-	serial := propagation.MarshalTraceContext(prop)
-	ctx, tr := NewTrace(context.Background(), serial)
+	ctx, tr := NewTrace(context.Background(), prop)
 
 	assert.NotNil(t, tr.builder, "traces should have a builder")
 	assert.Equal(t, prop.TraceID, tr.traceID, "trace id should have propagated")
@@ -452,7 +451,7 @@ func TestPropagatedFields(t *testing.T) {
 	trFromContext := GetTraceFromContext(ctx)
 	assert.Equal(t, tr, trFromContext, "new trace should put the trace in the context")
 
-	_, tr2 := NewTrace(context.Background(), tr.GetRootSpan().SerializeHeaders())
+	_, tr2 := NewTrace(context.Background(), tr.GetRootSpan().PropagationContext())
 	assert.Equal(t, tr.traceID, tr2.traceID, "trace ID should shave propagated")
 	assert.NotEqual(t, tr.parentID, tr2.parentID, "parent ID should have changed")
 	assert.Equal(t, tr.builder.Dataset, tr2.builder.Dataset, "dataset should have propagated")
@@ -466,15 +465,14 @@ func TestPropagatedFields(t *testing.T) {
 			"userID": float64(1),
 		},
 	}
-	serial = propagation.MarshalTraceContext(prop)
-	ctx, tr = NewTrace(context.Background(), serial)
+	ctx, tr = NewTrace(context.Background(), prop)
 	assert.NotNil(t, tr.builder, "traces should have a builder")
 	assert.Equal(t, "trace id", tr.traceID, "trace id should have propagated")
 	assert.Equal(t, "parent id", tr.parentID, "parent id should have propagated")
 	assert.Equal(t, prop.Dataset, tr.builder.Dataset, "dataset should have propagated")
 	assert.Equal(t, prop.TraceContext, tr.traceLevelFields, "trace fields should have propagated")
 
-	ctx, tr = NewTrace(context.Background(), "garbage")
+	ctx, tr = NewTrace(context.Background(), nil)
 	assert.NotNil(t, tr.builder, "traces should have a builder")
 	assert.NotEqual(t, "", tr.traceID, "trace id should have propagated")
 	assert.Equal(t, "", tr.parentID, "parent id should have propagated")
@@ -484,7 +482,7 @@ func TestPropagatedFields(t *testing.T) {
 }
 
 func TestSerializePropagation(t *testing.T) {
-	_, tr := NewTrace(context.Background(), "")
+	_, tr := NewTrace(context.Background(), nil)
 	sp := tr.GetRootSpan()
 	serialized := sp.SerializeHeaders()
 	assert.NotEmpty(t, serialized, "serialized headers on a span should not be empty")
@@ -494,7 +492,7 @@ func TestSerializePropagation(t *testing.T) {
 }
 
 func TestSerializePropagationDoesNotRaceWithTraceFields(t *testing.T) {
-	_, tr := NewTrace(context.Background(), "")
+	_, tr := NewTrace(context.Background(), nil)
 	sp := tr.GetRootSpan()
 
 	// simultaneously serialize headers and modify the trace leve fields map
@@ -550,7 +548,7 @@ func TestGetNewID(t *testing.T) {
 // check to ensure that we don't regress the performance of sending spans.
 func BenchmarkSendChildSpans(b *testing.B) {
 	setupLibhoney()
-	ctx, tr := NewTrace(context.Background(), b.Name())
+	ctx, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -563,7 +561,7 @@ func BenchmarkSendChildSpans(b *testing.B) {
 func BenchmarkSendSpan(b *testing.B) {
 	setupLibhoney()
 
-	_, tr := NewTrace(context.Background(), b.Name())
+	_, tr := NewTrace(context.Background(), nil)
 	rs := tr.GetRootSpan()
 	for n := 0; n < b.N; n++ {
 		rs.sendLocked()

--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -62,7 +62,8 @@ func StartSpanOrTraceFromHTTPWithTraceParserHook(r *http.Request, parserHook con
 		var tr *trace.Trace
 		if parserHook == nil {
 			beelineHeader := r.Header.Get(propagation.TracePropagationHTTPHeader)
-			ctx, tr = trace.NewTrace(ctx, beelineHeader)
+			prop, _ := propagation.UnmarshalHoneycombTraceContext(beelineHeader)
+			ctx, tr = trace.NewTrace(ctx, prop)
 		} else {
 			// Call the provided TraceParserHook to get the propagation context
 			// from the incoming request. This information will then be used when
@@ -204,7 +205,7 @@ func BuildDBSpan(ctx context.Context, bld *libhoney.Builder, stats sql.DBStats, 
 		// least confusing possibility. Would be nice to indicate this had
 		// happened in a better way than yet another meta. field.
 		var tr *trace.Trace
-		ctx, tr = trace.NewTrace(ctx, "")
+		ctx, tr = trace.NewTrace(ctx, nil)
 		span = tr.GetRootSpan()
 		span.AddField("meta.orphaned", true)
 	} else {

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -44,13 +44,14 @@ func startSpanOrTraceFromUnaryGRPC(
 		if ok {
 			if parserHook == nil {
 				beelineHeader := getMetadataStringValue(md, propagation.TracePropagationGRPCHeader)
-				ctx, tr = trace.NewTrace(ctx, beelineHeader)
+				prop, _ := propagation.UnmarshalHoneycombTraceContext(beelineHeader)
+				ctx, tr = trace.NewTrace(ctx, prop)
 			} else {
 				prop := parserHook(ctx)
 				ctx, tr = trace.NewTraceFromPropagationContext(ctx, prop)
 			}
 		} else {
-			ctx, tr = trace.NewTrace(ctx, "")
+			ctx, tr = trace.NewTrace(ctx, nil)
 		}
 		span = tr.GetRootSpan()
 	} else {


### PR DESCRIPTION
Update propagation deprecations:
* NewTrace now takes a propagationContext instead of Headers