### PR TITLE
Capture correct request.host value on http client redirects

### DIFF
--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -89,6 +89,10 @@ func GetRequestProps(req *http.Request) map[string]interface{} {
 	userAgent := req.UserAgent()
 	xForwardedFor := req.Header.Get("x-forwarded-for")
 	xForwardedProto := req.Header.Get("x-forwarded-proto")
+	host := req.Host
+	if host == "" {
+		host = req.URL.Hostname()
+	}
 
 	reqProps := make(map[string]interface{})
 	// identify the type of event
@@ -101,7 +105,7 @@ func GetRequestProps(req *http.Request) map[string]interface{} {
 		reqProps["request.query"] = req.URL.RawQuery
 	}
 	reqProps["request.url"] = req.URL.String()
-	reqProps["request.host"] = req.Host
+	reqProps["request.host"] = host
 	reqProps["request.http_version"] = req.Proto
 	reqProps["request.content_length"] = req.ContentLength
 	reqProps["request.remote_addr"] = req.RemoteAddr


### PR DESCRIPTION
I've found that when using `hnynethttp.WrapRoundTripper`, the `request.host` property is left empty on spans generated  when the http client follows 3xx redirects (as when making a GET request to a shortened URL). This change ensures that the `request.host` property populated as expected on those spans.

This snippet from the documentation for the `URL` field on the [`http.Request` struct](https://golang.org/pkg/net/http/#Request) helps explain why `req.Host` is often empty on client requests (emphasis added):

> // For client requests, the URL's Host specifies the server to
> // connect to, while the Request's Host field **_optionally_**
> // specifies the Host header value to send in the HTTP
> // request. 