### PR TITLE
Fix go.sum and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           race: true
           verbose: true
           covermode: atomic
+      - run: go version
   publish_github:
     docker:
       - image: cibuilds/github:0.13.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,11 @@ jobs:
     steps:
       - checkout
       - go/load-cache
-      - go/mod-download
-      - go/save-cache
       - go/test:
           race: true
           verbose: true
           covermode: atomic
-      - run: go version
+      - go/save-cache
   publish_github:
     docker:
       - image: cibuilds/github:0.13.0

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
* Add missing entry in go.sum
* Since go 1.16, go.mod and go.sum are no longer automatically fixed: https://blog.golang.org/go116-module-changes#TOC_3.
* CI was passing on 1.16, because we were doing `go mod download` before running the tests, which was updating the go.sum
* Now it will fail: https://app.circleci.com/pipelines/github/honeycombio/beeline-go/752/workflows/e50bcef6-52fc-4674-a516-148ff9e07930/jobs/2363
* Fixes #226 