### PR TITLE
feat: span.AddField() support adding error

### DIFF
--- a/beeline.go
+++ b/beeline.go
@@ -213,6 +213,9 @@ func Close() {
 // context from the request (`r.Context()`) and the key and value you wish to
 // add.This function is good for span-level data, eg timers or the arguments to
 // a specific function call, etc. Fields added here are prefixed with `app.`
+//
+// Errors are treated as a special case for convenience: if `val` is of type
+// `error` then the key is set to the error's message in the span.
 func AddField(ctx context.Context, key string, val interface{}) {
 	span := trace.GetSpanFromContext(ctx)
 	if span != nil {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -264,8 +264,7 @@ func (s *Span) AddField(key string, val interface{}) {
 	s.eventLock.Lock()
 	defer s.eventLock.Unlock()
 	if s.ev != nil {
-		err, ok := val.(error)
-		if ok {
+		if err, ok := val.(error); ok {
 			s.ev.AddField(key, err.Error())
 		} else {
 			s.ev.AddField(key, val)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"go.opentelemetry.io/otel/trace"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/honeycombio/beeline-go/client"
 	"github.com/honeycombio/beeline-go/propagation"
@@ -254,13 +255,21 @@ func newSpan() *Span {
 }
 
 // AddField adds a key/value pair to this span
+//
+// Errors are treated as a special case for convenience: if `val` is of type
+// `error` then the key is set to the error's message in the span.
 func (s *Span) AddField(key string, val interface{}) {
 	// The call to event's AddField is protected by a lock, but this is not always sufficient
 	// See send for why this lock exists
 	s.eventLock.Lock()
 	defer s.eventLock.Unlock()
 	if s.ev != nil {
-		s.ev.AddField(key, val)
+		err, ok := val.(error)
+		if ok {
+			s.ev.AddField(key, err.Error())
+		} else {
+			s.ev.AddField(key, val)
+		}
 	}
 }
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -15,7 +15,6 @@ import (
 	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestNewTraceFromSerializedHeaders create traces and make sure they're populated with all the

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -104,7 +104,6 @@ func TestAddField(t *testing.T) {
 	_, tr := NewTrace(context.Background(), nil)
 	tr.AddField("wander", "lust")
 	assert.Equal(t, "lust", tr.traceLevelFields["wander"], "AddField on a trace should add the field to the trace level fields map")
-
 }
 
 // TestRollupField tests adding a field to a trace

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -250,7 +250,7 @@ func TestSpan(t *testing.T) {
 	span.AddField("error", expected)
 	assert.Contains(t, span.ev.Fields(), "error")
 	msg, ok := span.ev.Fields()["error"].(string)
-	require.True(t, ok)
+	assert.Equal(t, true, ok)
 	assert.Equal(t, expected.Error(), msg)
 
 	// add some rollup fields


### PR DESCRIPTION
Small tweak to allow `span.AddField()` to support adding error types, similar to `beeline.AddField()`.