### PR TITLE
Prepare 1.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Release v1.1.3 (2021-07-13)
+
+### Dependencies
+
+- Bump go.opentelemetry.io/contrib/propagators from 0.20.0 to 0.21.0 (#237)
+- Bump github.com/honeycombio/libhoney-go from 1.15.2 to 1.15.3 (#236)
+
+### Maintenance
+
+- Updates Github Action Workflows (#243)
+- Updates Dependabot Config (#240)
+- Switches CODEOWNERS to telemetry-team (#239)
+
 # Release v1.1.2 (2021-06-03)
 
 ### Dependencies

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "1.1.2"
+const version = "1.1.3"


### PR DESCRIPTION
Sets version to `1.1.3` and updates changelog with changes since 1.1.2 release.