### PR TITLE
fix(echo): this change ensures honeycomb captures errors correctly

### DIFF
--- a/wrappers/hnyecho/echo.go
+++ b/wrappers/hnyecho/echo.go
@@ -49,12 +49,17 @@ func (e *EchoWrapper) Middleware() echo.MiddlewareFunc {
 
 			// invoke next middleware in chain
 			err := next(c)
+			if err != nil {
+				span.AddField("echo.error", err.Error())
+				// invokes the registered HTTP error handler
+				c.Error(err)
+			}
 
 			// add fields for http response code and size
 			span.AddField("response.status_code", c.Response().Status)
 			span.AddField("response.size", c.Response().Size)
 
-			return err
+			return nil
 		}
 	}
 }

--- a/wrappers/hnyecho/echo_test.go
+++ b/wrappers/hnyecho/echo_test.go
@@ -1,28 +1,25 @@
 package hnyecho
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	beeline "github.com/honeycombio/beeline-go"
-	libhoney "github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/beeline-go"
+	"github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	errWoops = errors.New("woops")
+)
+
 func TestEchoMiddleware(t *testing.T) {
-	// set up libhoney to catch events instead of send them
-	evCatcher := &transmission.MockSender{}
-	client, err := libhoney.NewClient(libhoney.ClientConfig{
-		APIKey:       "abcd",
-		Dataset:      "efgh",
-		APIHost:      "ijkl",
-		Transmission: evCatcher,
-	})
-	assert.Equal(t, nil, err)
-	beeline.Init(beeline.Config{Client: client})
+	evCatcher := beelineSetup(t)
+
 	// build a sample request to generate an event
 	r, _ := http.NewRequest("GET", "/hello/pooh", nil)
 	w := httptest.NewRecorder()
@@ -63,6 +60,55 @@ func TestEchoMiddleware(t *testing.T) {
 	assert.Equal(t, "pooh", name, "successfully served request should have path param 'name' populated")
 }
 
+func TestEchoMiddlewareErrors(t *testing.T) {
+	evCatcher := beelineSetup(t)
+
+	// build a sample request to generate an event
+	r, _ := http.NewRequest("GET", "/error", nil)
+	w := httptest.NewRecorder()
+
+	// set up the Echo router with the EchoWrapper middleware
+	router := echo.New()
+	router.Use(New().Middleware())
+	router.GET("/error", errorHandler)
+	// handle the request
+	router.ServeHTTP(w, r)
+
+	// verify the MockOutput caught the well formed event
+	evs := evCatcher.Events()
+	assert.Equal(t, 1, len(evs), "one event is created with one request through the Middleware")
+	fields := evs[0].Data
+	// status code
+	status, ok := fields["response.status_code"]
+	assert.True(t, ok, "response.status_code field must exist on middleware generated event")
+	assert.Equal(t, 500, status, "successfully served request should have status 500")
+
+	// response error
+	echoErr, ok := fields["echo.error"]
+	assert.True(t, ok, "echo.error field must exist on middleware generated event")
+	assert.Equal(t, errWoops.Error(), echoErr)
+
+}
+
+func beelineSetup(t *testing.T) *transmission.MockSender {
+	// set up libhoney to catch events instead of send them
+	evCatcher := &transmission.MockSender{}
+	client, err := libhoney.NewClient(libhoney.ClientConfig{
+		APIKey:       "abcd",
+		Dataset:      "efgh",
+		APIHost:      "ijkl",
+		Transmission: evCatcher,
+	})
+	assert.Equal(t, nil, err)
+	beeline.Init(beeline.Config{Client: client})
+
+	return evCatcher
+}
+
 func helloHandler(c echo.Context) error {
 	return c.String(http.StatusOK, "ok")
+}
+
+func errorHandler(c echo.Context) error {
+	return errWoops
 }

--- a/wrappers/hnyecho/hnyecho_test.go
+++ b/wrappers/hnyecho/hnyecho_test.go
@@ -15,5 +15,6 @@ func ExampleMiddleware() {
 	router.GET("/bye/:name", bye)
 
 	// add hnyecho to middleware chain to provide honeycomb instrumentation
+	// note this should be registered first to enable capturing of errors
 	router.Use(New().Middleware())
 }


### PR DESCRIPTION
This follows the pattern implemented in the opentracing echo middleware which ensures the registered error handler is invoked prior to completing the trace, otherwise echo doesn't capture the actual response code to the client.

For reference this is the opentelementry code https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/github.com/labstack/echo/otelecho/echo.go#L79-L92

I have included a test which demonstrates the problem.