### PR TITLE
Wrappers: add cfg to disable client spans

### DIFF
--- a/wrappers/config/config.go
+++ b/wrappers/config/config.go
@@ -39,6 +39,9 @@ type HTTPIncomingConfig struct {
 // instrumented application.
 type HTTPOutgoingConfig struct {
 	HTTPPropagationHook HTTPTracePropagationHook
+	// If DisableClientSpans is true, the client wrapper will propagate existing span
+	// metadata instead of of creating and propagating a new span.
+	DisableClientSpans bool
 }
 
 // GRPCTraceParserHook is a function that will be invoked on all incoming gRPC requests
@@ -65,4 +68,7 @@ type GRPCIncomingConfig struct {
 // by an instrumented application.
 type GRPCOutgoingConfig struct {
 	GRPCPropagationHook GRPCTracePropagationHook
+	// If DisableClientSpans is true, the client wrapper will propagate existing span
+	// metadata instead of of creating and propagating a new span.
+	DisableClientSpans bool
 }

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -158,12 +158,14 @@ func UnaryClientInterceptorWithConfig(cfg config.GRPCOutgoingConfig) grpc.UnaryC
 			return err
 		}
 
-		ctx, span = span.CreateChild(ctx)
-		defer span.Send()
+		if !cfg.DisableClientSpans {
+			ctx, span = span.CreateChild(ctx)
+			defer span.Send()
 
-		span.AddField("name", method)
-		span.AddField("meta.type", "grpc_client")
-		span.AddField("request.target", cc.Target())
+			span.AddField("name", method)
+			span.AddField("meta.type", "grpc_client")
+			span.AddField("request.target", cc.Target())
+		}
 
 		md, ok := metadata.FromOutgoingContext(ctx)
 		if !ok {


### PR DESCRIPTION
Add a new `DisableClientSpans` config parameter to the hnynethttp and
hnygrpc wrappers. By default (when set to the Go zero-value, or when
created using the default wrapper constructors), this has no effect.
When specifically set to `true`, this config parameter suppresses the
creation of new spans by the client wrappers. The trace propagation
metadata is still sent with the request, but the span ID is the ID of
the current span, not the ID of a newly-created span.

This allows users to decide whether or not they care about client spans
independently of whether they care about trace propagation. Since client
spans can nearly double the total number of spans sent by a microservice
architecture, this can be an important knob to tune.

Fixes #272