### PR TITLE
add min go verison to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package makes it easy to instrument your Go app to send useful events to [H
 
 ## Dependencies
 
-The beeline uses [go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) to track external dependencies: golang 1.11 or newer is therefore required to build
+Golang 1.14+
 
 ## Contributions
 


### PR DESCRIPTION
Go 1.14+ is required since [v1.0.0](https://github.com/honeycombio/beeline-go/releases/tag/v1.0.0)