### PR TITLE
[hnysqlx] change db.caller to walk the stack until it finds a non-database function name to allow additional nesting abstractions

### DIFF
--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -121,46 +121,117 @@ func GetRequestProps(req *http.Request) map[string]interface{} {
 	return reqProps
 }
 
-// getCallersNames grabs the current call stack, skips up a few levels, then
-// grabs as many function names as depth. Suggested use is something like 1, 2
-// meaning "get my parent and its parent". skip=0 means the function calling
-// this one.
-func getCallersNames(skip, depth int) []string {
-	callers := make([]string, 0, depth)
+var dbNames = map[string]interface{}{
+	"BindNamed":           nil,
+	"Beginx":              nil,
+	"BeginTxx":            nil,
+	"Exec":                nil,
+	"ExecContext":         nil,
+	"Get":                 nil,
+	"GetContext":          nil,
+	"MapperFunc":          nil,
+	"MustBegin":           nil,
+	"MustBeginTx":         nil,
+	"MustExec":            nil,
+	"MustExecContext":     nil,
+	"NamedExec":           nil,
+	"NamedExecContext":    nil,
+	"NamedQuery":          nil,
+	"NamedQueryContext":   nil,
+	"Ping":                nil,
+	"PingContext":         nil,
+	"PrepareNamed":        nil,
+	"PrepareNamedContext": nil,
+	"Preparex":            nil,
+	"PreparexContext":     nil,
+	"Query":               nil,
+	"QueryContext":        nil,
+	"QueryRow":            nil,
+	"QueryRowContext":     nil,
+	"Queryx":              nil,
+	"QueryxContext":       nil,
+	"QueryRowx":           nil,
+	"QueryRowxContext":    nil,
+	"Rebind":              nil,
+	"Select":              nil,
+	"SelectContext":       nil,
+	"Close":               nil,
+	"Driver":              nil,
+	"SetConnMaxLifetime":  nil,
+	"SetMaxIdleConns":     nil,
+	"SetMaxOpenConns":     nil,
+	// and now some function names from this instrumentation
+	"getNonDBCallerName": nil,
+	"sharedDBEvent":      nil,
+	"BuildDBEvent":       nil,
+	"BuildDBSpan":        nil,
+	// and now some unnamed functions
+	"func1": nil,
+}
+
+var localNames = map[string]interface{}{
+	// and now some function names from this instrumentation
+	"getNonDBCallerName": nil,
+	"sharedDBEvent":      nil,
+	"BuildDBEvent":       nil,
+	"BuildDBSpan":        nil,
+	// and now some unnamed functions
+	"func1": nil,
+}
+
+// getCallersNames grabs the current call stack, skips up out of runtime, then
+// grabs as many function names as depth. It then walks up the tree until it
+// finds a name that is not one of the official sqlx names or a name from this
+// instrumentation. It uses that for the name of the span to indicate who is
+// calling into the sqlx instrumentation.
+func getCallersNames() (dbcall string, caller string) {
+	depth := 10 // how big a stack do we want to check
+	skip := 1   // how many steps do we jump up from here? skip runtime.
+
 	callerPcs := make([]uintptr, depth)
 	// add 2 to skip to account for runtime.Callers and getCallersNames
 	numCallers := runtime.Callers(skip+2, callerPcs)
 	// If there are no callers, the entire stacktrace is nil
 	if numCallers == 0 {
-		return callers
+		return
 	}
 	callersFrames := runtime.CallersFrames(callerPcs)
 	for i := 0; i < depth; i++ {
 		fr, more := callersFrames.Next()
 		// store the function's name
 		nameParts := strings.Split(fr.Function, ".")
-		callers = append(callers, nameParts[len(nameParts)-1])
+		caller = nameParts[len(nameParts)-1]
+		if _, ok := dbNames[caller]; ok {
+			// we've found the DB call, record the first one to ensure it's the lowest
+			// skip the names in this wrapper though
+			if _, ok := localNames[caller]; !ok {
+				if dbcall == "" {
+					dbcall = caller
+				}
+			}
+		} else {
+			// we've found a function name that's not a DB call, return it
+			return
+		}
 		if !more {
 			break
 		}
 	}
-	return callers
+	// well we didn't find one but let's return what we've got
+	return
 }
 
 func sharedDBEvent(bld *libhoney.Builder, query string, args ...interface{}) *libhoney.Event {
 	ev := bld.NewEvent()
 
 	// skip 2 - this one and the buildDB*, so we get the sqlx function and its parent
-	callerNames := getCallersNames(2, 2)
-	switch len(callerNames) {
-	case 2:
-		ev.AddField("db.call", callerNames[0])
-		ev.AddField("name", callerNames[0])
-		ev.AddField("db.caller", callerNames[1])
-	case 1:
-		ev.AddField("db.call", callerNames[0])
-		ev.AddField("name", callerNames[0])
-	default:
+	dbcall, dbcaller := getCallersNames()
+	ev.AddField("db.call", dbcall)
+	ev.AddField("db.caller", dbcaller)
+	ev.AddField("name", dbcaller)
+
+	// in case we got nothin, use a default for name. the db.* will be empty it's fine
+	if dbcaller == "" {
 		ev.AddField("name", "db")
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

The `db.call` and `db.caller` fields were added way back in https://github.com/honeycombio/beeline-go/pull/25. They are supposed to represent the name of the function in the sqlx package being called (eg `GetContext`) and the name of the function that is calling into the DB object (eg `FindDatasetByID`). 

The original implementation of this functionality was a bit naïve and just said "well I'm going to guess that the caller is probably 2 steps up the stack. Let's just use that, whatever it may be.". This works fine if you have no abstraction around your DB, but if you create an additional wrapper around `hnysqlx`, suddenly both `db.call` and `db.caller` are something like `GetContext` and your instrumentation is sad. 

This change adjusts the logic of the function that searches for `db.caller`. Instead of just looking two levels up the stack, it walks the stack, ignoring known function names (since the interface for `sqlx` is well defined this is a complete list) until it finds one it doesn't recognize. It declares that this boundary is the function that is calling into the instrumentation and uses that.

The existing tests don't exercise an additional wrapper, but they do continue to pass. The existing functionality should be unchanged, so that's a good sign. I tested this with an application that uses an additional wrapper layer and included screenshots of the change.

![Image 2021-10-14 at 12 41 55 AM](https://user-images.githubusercontent.com/361454/137273722-66c9c08e-7eee-437b-8bbc-6d0f33c8e975.jpg)

![Image 2021-10-14 at 12 43 39 AM](https://user-images.githubusercontent.com/361454/137273754-2cd6d216-faf2-4b06-b97c-1d6b4b2ec3ad.jpg)


