### PR TITLE
[sql instrumentation] set name field to db call, not caller

### DIFF
--- a/wrappers/common/common.go
+++ b/wrappers/common/common.go
@@ -231,7 +231,7 @@ func sharedDBEvent(bld *libhoney.Builder, query string, args ...interface{}) *li
 	ev.AddField("name", dbcall)
 
 	// in case we got nothin, use a default for name. the db.* will be empty it's fine
-	if dbcaller == "" {
+	if dbcall == "" {
 		ev.AddField("name", "db")
 	}
 


### PR DESCRIPTION
To keep with the data model of the name of the span representing the thing that it's doing, using the caller as the name is the wrong choice; it should be the db call being run. 

When https://github.com/honeycombio/beeline-go/pull/280 landed it inadvertently changed the behavior from the [original PR](https://github.com/honeycombio/beeline-go/pull/25) it referenced (where `name` matched `db.call`, not `db.caller`). This change undoes that aspect of #280, returning it to the way it was, while keeping the changed method fo resolving `db.caller`.  h/t @dstrelau for catching the unexpected change.

Keep db.caller as a separate field, useful when invoked, but use `Get` or `GetContext` and so on as the name of the span.
