### PR TITLE
[hnygrpc] add a human readable version of the grpc status code to auto instrumentation

### DIFF
--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -109,7 +109,9 @@ func UnaryServerInterceptorWithConfig(cfg config.GRPCIncomingConfig) grpc.UnaryS
 		if err != nil {
 			span.AddTraceField("handler_error", err.Error())
 		}
-		span.AddField("response.grpc_status_code", status.Code(err))
+		code := status.Code(err)
+		span.AddField("response.grpc_status_code", code)
+		span.AddField("response.grpc_status_message", code.String())
 		return resp, err
 	}
 }

--- a/wrappers/hnygrpc/grpc_test.go
+++ b/wrappers/hnygrpc/grpc_test.go
@@ -118,4 +118,8 @@ func TestUnaryInterceptor(t *testing.T) {
 	status, ok := successfulFields["response.grpc_status_code"]
 	assert.True(t, ok, "Status code must exist on middleware generated event")
 	assert.Equal(t, codes.OK, status, "status must exist")
+
+	statusMsg, ok := successfulFields["response.grpc_status_message"]
+	assert.True(t, ok, "Status message must exist on middleware generated event")
+	assert.Equal(t, codes.OK.String(), statusMsg, "human-readable status must exist")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When looking at traffic instrumented with `hnygrpc`, I break down by `handler.method` and `response.grpc_status_code`. This is all well and good, but what I get back for the status code is 0,12, 16. 

While HTTP has been around long enough that many folks know what 200 and 404 mean, I don't have the same drilled-in understanding of what grpc codes 12 and 16 are. (turns out, `Unimplemented` and `Unauthenticated`. [reference](https://pkg.go.dev/google.golang.org/grpc@v1.40.0/codes#Code))

## Short description of the changes

To aid the people using this instrumentation, this change augments `response.grpc_status_code` with `response.grpc_status_message` that contains the `.String()` version of the code, so people can see `Unimplemented` next to `12` when looking at their responses. 
