### PR TITLE
parse incoming w3c header by default

### DIFF
--- a/propagation/w3c.go
+++ b/propagation/w3c.go
@@ -11,7 +11,7 @@ import (
 const (
 	supportedVersion  = 0
 	maxVersion        = 254
-	traceparentHeader = "traceparent"
+	TraceparentHeader = "traceparent"
 	tracestateHeader  = "tracestate"
 )
 
@@ -50,7 +50,7 @@ func MarshalW3CTraceContext(ctx context.Context, prop *PropagationContext) (cont
 		spanID,
 		flags)
 
-	headerMap[traceparentHeader] = h
+	headerMap[TraceparentHeader] = h
 	return ctx, headerMap
 }
 
@@ -66,7 +66,7 @@ func MarshalW3CTraceContext(ctx context.Context, prop *PropagationContext) (cont
 func UnmarshalW3CTraceContext(ctx context.Context, headers map[string]string) (context.Context, *PropagationContext, error) {
 	prop := &PropagationContext{}
 
-	h := getHeaderValue(headers, traceparentHeader)
+	h := getHeaderValue(headers, TraceparentHeader)
 	if h == "" {
 		return ctx, prop, errors.New("cannot unmarshal empty header")
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #286 

## Short description of the changes

- preference: parser hook > honeycomb > w3c
