### PR TITLE
feat: pass process root span id as pprof profile id tag

### DIFF
--- a/beeline.go
+++ b/beeline.go
@@ -91,6 +91,9 @@ type Config struct {
 	// Client, if specified, allows overriding the default client used to send events to Honeycomb
 	// If set, overrides many fields in this config - see descriptions
 	Client *libhoney.Client
+
+	// PprofTagging controls whether span IDs should be propagated to pprof.
+	PprofTagging bool
 }
 
 // Init intializes the honeycomb instrumentation library.
@@ -184,6 +187,8 @@ func Init(config Config) {
 	if config.PresendHook != nil {
 		trace.GlobalConfig.PresendHook = config.PresendHook
 	}
+
+	trace.GlobalConfig.PprofTagging = config.PprofTagging
 	return
 }
 

--- a/trace/context.go
+++ b/trace/context.go
@@ -3,11 +3,13 @@ package trace
 import (
 	"context"
 	"errors"
+	"runtime/pprof"
 )
 
 const (
 	honeySpanContextKey  = "honeycombSpanContextKey"
 	honeyTraceContextKey = "honeycombTraceContextKey"
+	profileIDLabelName   = "profile_id"
 )
 
 var (
@@ -31,7 +33,12 @@ func GetTraceFromContext(ctx context.Context) *Trace {
 // into the context.  It will replace any traces that already exist in the
 // context. Traces put in context are retrieved using GetTraceFromContext.
 func PutTraceInContext(ctx context.Context, trace *Trace) context.Context {
-	return context.WithValue(ctx, honeyTraceContextKey, trace)
+	ctx = context.WithValue(ctx, honeyTraceContextKey, trace)
+	if trace != nil && trace.GetRootSpan() != nil {
+		ctx = pprof.WithLabels(ctx, pprof.Labels(profileIDLabelName, trace.GetRootSpan().GetSpanID()))
+		pprof.SetGoroutineLabels(ctx)
+	}
+	return ctx
 }
 
 // GetSpanFromContext identifies the currently active span via the span context

--- a/trace/context.go
+++ b/trace/context.go
@@ -34,7 +34,7 @@ func GetTraceFromContext(ctx context.Context) *Trace {
 // context. Traces put in context are retrieved using GetTraceFromContext.
 func PutTraceInContext(ctx context.Context, trace *Trace) context.Context {
 	ctx = context.WithValue(ctx, honeyTraceContextKey, trace)
-	if trace != nil && trace.GetRootSpan() != nil {
+	if GlobalConfig.PprofTagging && trace != nil && trace.GetRootSpan() != nil {
 		ctx = pprof.WithLabels(ctx, pprof.Labels(profileIDLabelName, trace.GetRootSpan().GetSpanID()))
 		pprof.SetGoroutineLabels(ctx)
 	}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -27,6 +27,9 @@ type Config struct {
 	// PresendHook is a function to mutate spans just before they are sent to
 	// Honeycomb. See the docs for `beeline.Config` for a full description.
 	PresendHook func(map[string]interface{})
+
+	// PprofTagging controls whether span IDs should be propagated to pprof.
+	PprofTagging bool
 }
 
 // Trace holds some trace level state and the root of the span tree that will be


### PR DESCRIPTION
## Which problem is this PR solving?

- Implements the Honeycomb Beeline equivalent of the tracer to profiler data passing in [Pyroscope's demo PR](https://github.com/pyroscope-io/pyroscope/pull/766/files#diff-3bca24a7cb36f4a461afa30d9dc6b389b3e699d5c89710040b1121d162df1943R224)

Thanks to @kolesnikovae @petethepig and @Rperry2174 for your partnership so far!