### PR TITLE
fix: preserve previous pprof labels after span end

### DIFF
--- a/trace/context.go
+++ b/trace/context.go
@@ -33,9 +33,14 @@ func GetTraceFromContext(ctx context.Context) *Trace {
 // into the context.  It will replace any traces that already exist in the
 // context. Traces put in context are retrieved using GetTraceFromContext.
 func PutTraceInContext(ctx context.Context, trace *Trace) context.Context {
+	// Copy the old context object to preserve its pprof labels to restore later.
+	oldCtx := ctx
 	ctx = context.WithValue(ctx, honeyTraceContextKey, trace)
 	if GlobalConfig.PprofTagging && trace != nil && trace.GetRootSpan() != nil {
-		ctx = pprof.WithLabels(ctx, pprof.Labels(profileIDLabelName, trace.GetRootSpan().GetSpanID()))
+		// This returns a pointer type, so it's safe to directly manipulate fields.
+		rootSpan := trace.GetRootSpan()
+		rootSpan.oldCtx = &oldCtx
+		ctx = pprof.WithLabels(ctx, pprof.Labels(profileIDLabelName, rootSpan.GetSpanID()))
 		pprof.SetGoroutineLabels(ctx)
 	}
 	return ctx


### PR DESCRIPTION
Fixes bug in #305 where previous pprof context wouldn't get restored after span end in case goroutine is reused for something else.