### PR TITLE
maint: add go 1.18 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.7.0
+  go: circleci/go@1.7.1
 
 jobs:
   test:
     parameters:
       go-version:
         type: string
-        default: "1.14"
+        default: "1.18"
     executor:
       name: go/default
       tag: << parameters.go-version >>
@@ -46,6 +46,7 @@ workflows:
                 - "1.15"
                 - "1.16"
                 - "1.17"
+                - "1.18"
   build:
     jobs:
       - test:

--- a/beeline.go
+++ b/beeline.go
@@ -24,7 +24,6 @@ const (
 	defaultDataset        = "unknown_service"
 	defaultServiceName    = "unknown_service"
 	defaultSampleRate     = 1
-	warningColor          = "\033[1;33m%s\033[0m"
 )
 
 // Config is the place where you configure your Honeycomb write key and dataset
@@ -111,12 +110,12 @@ func Init(config Config) {
 	userAgentAddition := fmt.Sprintf("beeline/%s", version)
 
 	if config.WriteKey == "" {
-		fmt.Fprintln(os.Stderr,"WARN: Missing API Key.")
+		fmt.Fprintln(os.Stderr, "WARN: Missing API Key.")
 		config.WriteKey = defaultWriteKey
 	}
 
 	if config.ServiceName == "" {
-		fmt.Fprintln(os.Stderr,"WARN: Missing service name.")
+		fmt.Fprintln(os.Stderr, "WARN: Missing service name.")
 		// set default service name if not provided
 		config.ServiceName = defaultServiceName
 		if executable, err := os.Executable(); err == nil {
@@ -137,14 +136,14 @@ func Init(config Config) {
 	} else {
 		// non classic key will ignore dataset, warn if configured
 		if config.Dataset != "" {
-			fmt.Fprintln(os.Stderr,"WARN: Dataset is ignored in favor of service name. Data will be sent to service name:", config.ServiceName)
+			fmt.Fprintln(os.Stderr, "WARN: Dataset is ignored in favor of service name. Data will be sent to service name:", config.ServiceName)
 		}
 		// set dataset based on service name
 		config.Dataset = config.ServiceName
 
 		if strings.TrimSpace(config.Dataset) != config.Dataset {
 			// whitespace detected. trim whitespace, warn on diff
-			fmt.Fprintln(os.Stderr,"WARN: Service name has unexpected spaces")
+			fmt.Fprintln(os.Stderr, "WARN: Service name has unexpected spaces")
 			config.Dataset = strings.TrimSpace(config.Dataset)
 		}
 		if config.Dataset == "" {
@@ -174,9 +173,7 @@ func Init(config Config) {
 	if config.Client == nil {
 		var tx transmission.Sender
 		if config.STDOUT == true {
-			fmt.Println(
-				warningColor,
-				`WARNING: Writing to STDOUT in a production environment is dangerous and can cause issues.`)
+			fmt.Println(`WARNING: Writing to STDOUT in a production environment is dangerous and can cause issues.`)
 			tx = &transmission.WriterSender{}
 		}
 		if config.Mute == true {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- go 1.18 was released earlier this month

## Short description of the changes

- add 1.18 to test matrix
  - 1.18 failed `./beeline.go:177:4: fmt.Println call has possible formatting directive %s`
  - removed the warning color altogether, we're not using it for any other warnings
- update default version to 1.18
- bump go orb

