### PR TITLE
Prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.0.0 2022-04-04
 
+### !!! Breaking Changes !!!
+
+Minimum Go version required is now 1.16.
 ### Maintenance
 
 * Update gobuffalo/pop from v5 to v6, which uses features introduced in Go version 1.16.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # beeline-go changelog
 
+## 2.0.0 2022-04-04
+
+### Maintenance
+
+* Update gobuffalo/pop from v5 to v6, which uses features introduced in Go version 1.16.
+* Update google.golang.org/protobuf from 1.26.0 to 1.28.0.
+* Update google.golang.org/grpc from 1.43.0 to 1.45.0.
+* Update labstack/echo from 4.6.1 to 4.7.2.
+* Remove support for Go 1.14 and 1.15.
+* Add support for Go 1.18.
+* Major version bump since support for two versions of Go were removed.
+
 ## v1.7.0 2022-03-03
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package makes it easy to instrument your Go app to send useful events to [H
 
 ## Dependencies
 
-Golang 1.14+
+Golang 1.16+
 
 ## Contributions
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/beeline-go
 
-go 1.14
+go 1.16
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package beeline
 
-const version = "1.7.0"
+const version = "2.0.0"


### PR DESCRIPTION
Prep for release of 2.0.0. Requires #314 first.

