### PR TITLE
[optimization] simple concat for prepending "app."

### DIFF
--- a/beeline.go
+++ b/beeline.go
@@ -280,7 +280,7 @@ func AddField(ctx context.Context, key string, val interface{}) {
 	span := trace.GetSpanFromContext(ctx)
 	if span != nil {
 		if val != nil {
-			namespacedKey := fmt.Sprintf("app.%s", key)
+			namespacedKey := "app." + key // Avoid excess parsing/allocation work
 			if valErr, ok := val.(error); ok {
 				// treat errors specially because it's a pain to have to
 				// remember to stringify them
@@ -300,7 +300,7 @@ func AddField(ctx context.Context, key string, val interface{}) {
 // eg user IDs, globally relevant feature flags, errors, etc. Fields added here
 // are prefixed with `app.`
 func AddFieldToTrace(ctx context.Context, key string, val interface{}) {
-	namespacedKey := fmt.Sprintf("app.%s", key)
+	namespacedKey := "app." + key // Avoid excess parsing/allocation work
 	tr := trace.GetTraceFromContext(ctx)
 	if tr != nil {
 		tr.AddField(namespacedKey, val)


### PR DESCRIPTION
## Which problem is this PR solving?
- Instrumentation overhead in Shepherd is a wee bit too high. (Sprintf is the number one allocation source in https://pyroscope.prod.hny.wtf/?query=shepherd.alloc_objects%7B%7D&from=now-30m)

## Short description of the changes
- Avoid using fmt.Sprintf for a very simple operation. This hopefully gets rid of some inefficiency/allocations that otherwise are plaguing shepherd at high volume.