### PR TITLE
Add more request header information to GRPC handler spans

### DIFF
--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -18,6 +18,23 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// This is a map of GRPC request header names whose values will be retrieved
+// and added to handler spans as fields with the corresponding name.
+//
+// Header names must be lowercase as the metadata.MD API will have normalized
+// incoming headers to lower.
+//
+// The field names should turn dashes (-) into underscores (_) to follow
+// precident in HTTP request headers and the patterns established and in
+// naming patterns in OTel attributes for requests.
+var headersToFields = map[string]string{
+	"content-type":      "request.content_type",
+	":authority":        "request.header.authority",
+	"user-agent":        "request.header.user_agent",
+	"x-forwarded-for":   "request.header.x_forwarded_for",
+	"x-forwarded-proto": "request.header.x_forwarded_proto",
+}
+
 // getMetadataStringValue is a simpler helper method that checks the provided
 // metadata for a value associated with the provided key. If the value exists,
 // it is returned. If the value does not exist, an empty string is returned.
@@ -82,13 +99,6 @@ func addFields(ctx context.Context, info *grpc.UnaryServerInfo, handler grpc.Una
 		}
 	}
 
-	headersToFields := map[string]string{
-		"content-type":      "request.content_type",
-		":authority":        "request.header.authority",
-		"user-agent":        "request.header.user_agent",
-		"x-forwarded-for":   "request.header.x_forwarded_for",
-		"x-forwarded-proto": "request.header.x_forwarded_proto",
-	}
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		for headerName, fieldName := range headersToFields {

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -72,22 +72,19 @@ func addFields(ctx context.Context, info *grpc.UnaryServerInfo, handler grpc.Una
 	span.AddField("handler.name", handlerName)
 	span.AddField("handler.method", info.FullMethod)
 
+	headersToFields := map[string]string{
+		"content-type":      "request.content_type",
+		":authority":        "request.header.authority",
+		"user-agent":        "request.header.user_agent",
+		"x-forwarded-for":   "request.header.x_forwarded_for",
+		"x-forwarded-proto": "request.header.x_forwarded_proto",
+	}
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
-		if val, ok := md["content-type"]; ok {
-			span.AddField("request.content_type", val[0])
-		}
-		if val, ok := md[":authority"]; ok {
-			span.AddField("request.header.authority", val[0])
-		}
-		if val, ok := md["user-agent"]; ok {
-			span.AddField("request.header.user_agent", val[0])
-		}
-		if val, ok := md["x-forwarded-for"]; ok {
-			span.AddField("request.header.x_forwarded_for", val[0])
-		}
-		if val, ok := md["x-forwarded-proto"]; ok {
-			span.AddField("request.header.x_forwarded_proto", val[0])
+		for headerName, fieldName := range headersToFields {
+			if val, ok := md[headerName]; ok {
+				span.AddField(fieldName, val[0])
+			}
 		}
 	}
 }

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -2,6 +2,7 @@ package hnygrpc
 
 import (
 	"context"
+	"net"
 	"reflect"
 	"runtime"
 
@@ -13,6 +14,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -71,6 +73,13 @@ func addFields(ctx context.Context, info *grpc.UnaryServerInfo, handler grpc.Una
 	span.AddField("meta.type", "grpc_request")
 	span.AddField("handler.name", handlerName)
 	span.AddField("handler.method", info.FullMethod)
+
+	pr, ok := peer.FromContext(ctx)
+	if ok {
+		if pr.Addr != net.Addr(nil) {
+			span.AddField("request.remote_addr", pr.Addr.String())
+		}
+	}
 
 	headersToFields := map[string]string{
 		"content-type":      "request.content_type",

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -76,6 +76,7 @@ func addFields(ctx context.Context, info *grpc.UnaryServerInfo, handler grpc.Una
 
 	pr, ok := peer.FromContext(ctx)
 	if ok {
+		// if we have an address, put it on the span
 		if pr.Addr != net.Addr(nil) {
 			span.AddField("request.remote_addr", pr.Addr.String())
 		}

--- a/wrappers/hnygrpc/grpc.go
+++ b/wrappers/hnygrpc/grpc.go
@@ -83,6 +83,12 @@ func addFields(ctx context.Context, info *grpc.UnaryServerInfo, handler grpc.Una
 		if val, ok := md["user-agent"]; ok {
 			span.AddField("request.header.user_agent", val[0])
 		}
+		if val, ok := md["x-forwarded-for"]; ok {
+			span.AddField("request.header.x_forwarded_for", val[0])
+		}
+		if val, ok := md["x-forwarded-proto"]; ok {
+			span.AddField("request.header.x_forwarded_proto", val[0])
+		}
 	}
 }
 

--- a/wrappers/hnygrpc/grpc_test.go
+++ b/wrappers/hnygrpc/grpc_test.go
@@ -78,9 +78,11 @@ func TestUnaryInterceptor(t *testing.T) {
 	beeline.Init(beeline.Config{Client: client})
 
 	md := metadata.New(map[string]string{
-		"content-type": "application/grpc",
-		":authority":   "api.honeycomb.io:443",
-		"user-agent":   "testing-is-fun",
+		"content-type":      "application/grpc",
+		":authority":        "api.honeycomb.io:443",
+		"user-agent":        "testing-is-fun",
+		"X-Forwarded-For":   "10.11.12.13",
+		"X-Forwarded-Proto": "https",
 	})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -110,6 +112,14 @@ func TestUnaryInterceptor(t *testing.T) {
 	userAgent, ok := successfulFields["request.header.user_agent"]
 	assert.True(t, ok, "user-agent expected to exist on middleware generated event")
 	assert.Equal(t, "testing-is-fun", userAgent, "user-agent should be set")
+
+	xForwardedFor, ok := successfulFields["request.header.x_forwarded_for"]
+	assert.True(t, ok, "x_forwarded_for expected to exist on middleware generated event")
+	assert.Equal(t, "10.11.12.13", xForwardedFor, "x_forwarded_for should be set")
+
+	xForwardedProto, ok := successfulFields["request.header.x_forwarded_proto"]
+	assert.True(t, ok, "x_forwarded_proto expected to exist on middleware generated event")
+	assert.Equal(t, "https", xForwardedProto, "x_forwarded_proto should be set")
 
 	method, ok := successfulFields["handler.method"]
 	assert.True(t, ok, "method name should be set")

--- a/wrappers/hnygrpc/grpc_test.go
+++ b/wrappers/hnygrpc/grpc_test.go
@@ -81,7 +81,7 @@ func TestUnaryInterceptor(t *testing.T) {
 		"content-type":      "application/grpc",
 		":authority":        "api.honeycomb.io:443",
 		"user-agent":        "testing-is-fun",
-		"X-Forwarded-For":   "10.11.12.13",
+		"X-Forwarded-For":   "10.11.12.13", // headers are Kabob-Title-Case from clients
 		"X-Forwarded-Proto": "https",
 	})
 	ctx := metadata.NewIncomingContext(context.Background(), md)


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #339 

## Short description of the changes

- Adds the following fields to a GRPC handler span:
  - request.header.x_forwarded_for
  - request.header.x_forwarded_proto
  - request.remote_addr

- Refactored the existing if-chain to a loop of headers to check and add to span if present.
