### PR TITLE
pre-define capacities for rollups and TLFs

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -180,7 +180,7 @@ func (t *Trace) getTraceLevelFields() map[string]interface{} {
 	t.tlfLock.Lock()
 	defer t.tlfLock.Unlock()
 	// return a copy of trace level fields
-	retVals := make(map[string]interface{})
+	retVals := make(map[string]interface{}, len(t.traceLevelFields))
 	for k, v := range t.traceLevelFields {
 		retVals[k] = v
 	}
@@ -190,7 +190,7 @@ func (t *Trace) getTraceLevelFields() map[string]interface{} {
 func (t *Trace) getRollupFields() map[string]interface{} {
 	t.rollupLock.Lock()
 	defer t.rollupLock.Unlock()
-	rollupFields := make(map[string]interface{})
+	rollupFields := make(map[string]interface{}, len(t.rollupFields))
 	for k, v := range t.rollupFields {
 		rollupFields[k] = v
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- Similar to https://github.com/honeycombio/libhoney-go/pull/197, profiling shows we spend a lot of time in github.com/honeycombio/beeline-go/trace.(*Span).send generating the map.

## Short description of the changes

- define the map capacity in advance before returning it.

a subsequent follow-up might be allowing passing a map in its entirety to github.com/honeycombio/libhoney-go.(*Event).AddField so that the map entries do not need to be added one at a time when merging the maps together.

Or, better yet, https://github.com/golang/go/issues/56182 could prevent this problem by giving us a more sensible API for mass additions to a map.
