### PR TITLE
ci: add go 1.20 to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     parameters:
       go-version:
         type: string
-        default: "1.18"
+        default: "1.20"
     executor:
       name: go/default
       tag: << parameters.go-version >>
@@ -45,6 +45,7 @@ workflows:
                 - "1.17"
                 - "1.18"
                 - "1.19"
+                - "1.20"
   build:
     jobs:
       - test:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Go 1.20 was released in February!

## Short description of the changes

Add 1.20 to test matrix and use as default version.

