### PR TITLE
add otel recommendation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![CircleCI](https://circleci.com/gh/honeycombio/beeline-go.svg?style=shield)](https://circleci.com/gh/honeycombio/beeline-go)
 [![GoDoc](https://godoc.org/github.com/honeycombio/beeline-go?status.svg)](https://godoc.org/github.com/honeycombio/beeline-go)
 
+**Note**: Honeycomb embraces OpenTelemetry as the effective way to instrument applications. For any new observability efforts, we recommend [instrumenting with OpenTelemetry](https://docs.honeycomb.io/getting-data-in/opentelemetry-overview/).
+
 This package makes it easy to instrument your Go app to send useful events to [Honeycomb](https://www.honeycomb.io), a service for debugging your software in production.
 - [Usage and Examples](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/)
 - [API Reference](https://godoc.org/github.com/honeycombio/beeline-go)


### PR DESCRIPTION
## Which problem is this PR solving?
This addition to the README makes it clear that Honeycomb recommends instrumenting any new observability efforts with OpenTelemetry

## Short description of the changes
- Add paragraph to README recommending OTel

