### PR TITLE
perf: speed up adding fields, reduce memalloc if field name is already prefixed with "app."

### DIFF
--- a/beeline.go
+++ b/beeline.go
@@ -274,8 +274,10 @@ func Close() {
 // add.This function is good for span-level data, eg timers or the arguments to
 // a specific function call, etc.
 //
-// Field keys added will be prefixed with `app.` if the key does not already have
-// that prefix.
+// Field keys added will be prefixed with 'app.' if the prefix is not already
+// present on the key name. If you provide a key that starts with 'app.', both
+// speed and memory allocations are improved, especially within hot paths of
+// your application.
 //
 // Errors are treated as a special case for convenience: if `val` is of type
 // `error` then the key is set to the error's message in the span.
@@ -302,8 +304,10 @@ func AddField(ctx context.Context, key string, val interface{}) {
 // context that is better scoped to the request than this specific unit of work,
 // eg user IDs, globally relevant feature flags, errors, etc.
 //
-// Field keys added will be prefixed with `app.` if the key does not already have
-// that prefix.
+// Field keys added will be prefixed with 'app.' if the prefix is not already
+// present on the key name. If you provide a key that starts with 'app.', both
+// speed and memory allocations are improved, especially within hot paths of
+// your application.
 func AddFieldToTrace(ctx context.Context, key string, val interface{}) {
 	tr := trace.GetTraceFromContext(ctx)
 	if tr != nil {

--- a/beeline.go
+++ b/beeline.go
@@ -274,10 +274,10 @@ func Close() {
 // add.This function is good for span-level data, eg timers or the arguments to
 // a specific function call, etc.
 //
-// Field keys added will be prefixed with 'app.' if the prefix is not already
-// present on the key name. If you provide a key that starts with 'app.', both
-// speed and memory allocations are improved, especially within hot paths of
-// your application.
+// Field keys added will be prefixed with 'app.' if the 'app.' prefix is not
+// already present on the key name. If you provide a key that starts with
+// 'app.', both speed and memory allocations are improved, especially within hot
+// paths of your application.
 //
 // Errors are treated as a special case for convenience: if `val` is of type
 // `error` then the key is set to the error's message in the span.
@@ -304,10 +304,10 @@ func AddField(ctx context.Context, key string, val interface{}) {
 // context that is better scoped to the request than this specific unit of work,
 // eg user IDs, globally relevant feature flags, errors, etc.
 //
-// Field keys added will be prefixed with 'app.' if the prefix is not already
-// present on the key name. If you provide a key that starts with 'app.', both
-// speed and memory allocations are improved, especially within hot paths of
-// your application.
+// Field keys added will be prefixed with 'app.' if the 'app.' prefix is not
+// already present on the key name. If you provide a key that starts with
+// 'app.', both speed and memory allocations are improved, especially within hot
+// paths of your application.
 func AddFieldToTrace(ctx context.Context, key string, val interface{}) {
 	tr := trace.GetTraceFromContext(ctx)
 	if tr != nil {

--- a/beeline.go
+++ b/beeline.go
@@ -283,12 +283,13 @@ func AddField(ctx context.Context, key string, val interface{}) {
 	span := trace.GetSpanFromContext(ctx)
 	if span != nil {
 		if val != nil {
+			namespacedKey := getNamespacedKey(key)
 			if valErr, ok := val.(error); ok {
 				// treat errors specially because it's a pain to have to
 				// remember to stringify them
-				span.AddField(getNamespacedKey(key), valErr.Error())
+				span.AddField(namespacedKey, valErr.Error())
 			} else {
-				span.AddField(getNamespacedKey(key), val)
+				span.AddField(namespacedKey, val)
 			}
 		}
 	}
@@ -306,7 +307,8 @@ func AddField(ctx context.Context, key string, val interface{}) {
 func AddFieldToTrace(ctx context.Context, key string, val interface{}) {
 	tr := trace.GetTraceFromContext(ctx)
 	if tr != nil {
-		tr.AddField(getNamespacedKey(key), val)
+		namespacedKey := getNamespacedKey(key)
+		tr.AddField(namespacedKey, val)
 	}
 }
 

--- a/beeline.go
+++ b/beeline.go
@@ -280,11 +280,11 @@ func Close() {
 // paths of your application.
 //
 // Errors are treated as a special case for convenience: if `val` is of type
-// `error` then the key is set to the error's message in the span.
+// `error` then the field's value is set to the error's message.
 func AddField(ctx context.Context, key string, val interface{}) {
 	span := trace.GetSpanFromContext(ctx)
 	if span != nil {
-		if val != nil {
+		if val != nil { // TODO: move this to first check to save looking up the current span when there is no value?
 			namespacedKey := getNamespacedKey(key)
 			if valErr, ok := val.(error); ok {
 				// treat errors specially because it's a pain to have to

--- a/beeline_test.go
+++ b/beeline_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/honeycombio/beeline-go/trace"
 	"github.com/honeycombio/libhoney-go/transmission"
 
 	libhoney "github.com/honeycombio/libhoney-go"
@@ -107,11 +106,6 @@ func BenchmarkBeelineAddField(b *testing.B) {
 
 	ctx, _ := StartSpan(context.Background(), "parent")
 
-	b.Run("oldAddField/whatever", func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
-			oldAddField(ctx, "foo", 1)
-		}
-	})
 	b.Run("AddField/no-prefix", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			AddField(ctx, "foo", 1)
@@ -131,22 +125,6 @@ func BenchmarkBeelineAddField(b *testing.B) {
 			AddField(ctx, "app.foo", 1)
 		}
 	})
-}
-
-func oldAddField(ctx context.Context, key string, val interface{}) {
-	span := trace.GetSpanFromContext(ctx)
-	if span != nil {
-		if val != nil {
-			namespacedKey := "app." + key
-			if valErr, ok := val.(error); ok {
-				// treat errors specially because it's a pain to have to
-				// remember to stringify them
-				span.AddField(namespacedKey, valErr.Error())
-			} else {
-				span.AddField(namespacedKey, val)
-			}
-		}
-	}
 }
 
 func setupLibhoney(t testing.TB) *transmission.MockSender {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -260,7 +260,7 @@ func newSpan() *Span {
 // AddField adds a key/value pair to this span
 //
 // Errors are treated as a special case for convenience: if `val` is of type
-// `error` then the key is set to the error's message in the span.
+// `error` then the field's value is set to the error's message.
 func (s *Span) AddField(key string, val interface{}) {
 	// The call to event's AddField is protected by a lock, but this is not always sufficient
 	// See send for why this lock exists


### PR DESCRIPTION
 ## Which problem is this PR solving?

- Closes #401 

There is a remarkable amount of memory allocation occurring under load to perform the "app." prefixing of field names by the Beeline.

## Short description of the changes

This change skips the memory allocations needed for string concat and usage if the "app." prefix is already present on the field name provided.

### Benchmarks

Existing behavior is no slower or memory hungry, but for every field name provided by the Beeline user that starts with "app.", that is one less memory allocation of the size of the field name string.

```
BenchmarkBeelineAddField/oldAddField/whatever
BenchmarkBeelineAddField/oldAddField/whatever-12                19654003                60.52 ns/op            8 B/op          1 allocs/op
BenchmarkBeelineAddField/AddField/no-prefix
BenchmarkBeelineAddField/AddField/no-prefix-12                  18939754                60.65 ns/op            8 B/op          1 allocs/op
BenchmarkBeelineAddField/AddField/half-prefixed
BenchmarkBeelineAddField/AddField/half-prefixed-12              22405790                51.22 ns/op            4 B/op          0 allocs/op
BenchmarkBeelineAddField/AddField/all-prefixed
BenchmarkBeelineAddField/AddField/all-prefixed-12               27381916                42.88 ns/op            0 B/op          0 allocs/op
```
