### PR TITLE
maint: group patch updates for go deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/telemetry-team"
+    groups:
+      minor-patch:
+        update-types:
+        - "minor"
+        - "patch"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

Reduce the number of dependabot PRs

## Short description of the changes

- Groups minor and patch dependency updates into a single group.
