### PR TITLE
maint: drop go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,9 @@ workflows:
           matrix:
             parameters:
               go-version:
-                - "1.18"
                 - "1.19"
                 - "1.20"
+                - "1.21"
   build:
     jobs:
       - test:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package makes it easy to instrument your Go app to send useful events to [H
 
 ## Dependencies
 
-Golang 1.18+
+Golang 1.19+
 
 ## Contributions
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/beeline-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Which problem is this PR solving?

- sparked by https://github.com/honeycombio/beeline-go/pull/431
- 1.18 has been out of official support since 2023-02-01, when 1.20 was released

## Short description of the changes

- bump minimum go version to 1.19
- run `go mod tidy`

