### PR TITLE
maint: Add golang 1.22 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
                 - "1.19"
                 - "1.20"
                 - "1.21"
+                - "1.22"
   build:
     jobs:
       - test:


### PR DESCRIPTION
## Which problem is this PR solving?
Adds golang 1.22 to test matrix versions.

## Short description of the changes
- Add 1.22 to list of go versions in circle CI
