### PR TITLE
feat(trace): update profileIDLabelName to match Pyroscope

### DIFF
--- a/trace/context.go
+++ b/trace/context.go
@@ -9,7 +9,7 @@ import (
 const (
 	honeySpanContextKey  = "honeycombSpanContextKey"
 	honeyTraceContextKey = "honeycombTraceContextKey"
-	profileIDLabelName   = "profile_id"
+	profileIDLabelName   = "span_id"
 )
 
 var (


### PR DESCRIPTION
## Which problem is this PR solving?

- Adhere to format Pyroscope OSS expects per https://github.com/grafana/otel-profiling-go/commit/207e85a83187411fc33a161f38b64e90289e6302#diff-e4d4c63738d3e4e1bf4f34e59bf9df3dfc89e9eae421f2345b98dd4535125903

We've switched to using Pyroscope OSS internally rather than Pyroscope/Grafana Cloud, so we need to use the format that the current profiling solution expects for how span names are tagged when doing correlation of span and profile signals.