### PR TITLE
chore(dependabot): update team name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/pipeline-team"
     groups:
       minor-patch:
         update-types:


### PR DESCRIPTION
## Which problem is this PR solving?

- Dependabot is complaining telemetry-team no longer exists

## Short description of the changes

- s/telemetry/pipeline/

