### PR TITLE
maint: bump minimum Go version to 1.24, update test matrix to 1.24/1.25/1.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     parameters:
       go-version:
         type: string
-        default: "1.21"
+        default: "1.24"
     executor:
       name: go/default
       tag: << parameters.go-version >>
@@ -42,10 +42,9 @@ workflows:
           matrix:
             parameters:
               go-version:
-                - "1.21"
-                - "1.22"
-                - "1.23"
                 - "1.24"
+                - "1.25"
+                - "1.26"
   build:
     jobs:
       - test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/beeline-go
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1
 


### PR DESCRIPTION
## Which problem is this PR solving?

The CI test matrix was testing against Go 1.21-1.24, which includes EOL versions. This updates to currently supported Go releases.

## Short description of the changes

- **Breaking: bumps minimum supported Go version from 1.23 to 1.24**
- Update CircleCI test matrix from 1.21/1.22/1.23/1.24 to 1.24/1.25/1.26
- Update default go-version parameter to 1.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)